### PR TITLE
[Feat] 메인화면 랜덤 문구 설정 및 피드백 반영

### DIFF
--- a/Sodam/Sodam/Main/View/CustomTabBar.swift
+++ b/Sodam/Sodam/Main/View/CustomTabBar.swift
@@ -7,13 +7,13 @@
 
 import UIKit
 
-class CustomTabBar: UITabBar {
+final class CustomTabBar: UITabBar {
     override func sizeThatFits(_ size: CGSize) -> CGSize {
         var newSize = super.sizeThatFits(size)
         
         // 기기 화면 높이에 따라 탭바 높이 계산하기
-        let scrrenHeight = UIScreen.main.bounds.height
-        newSize.height = scrrenHeight * 0.11 // 화면 높이의 10%로 고정
+        let screenHeight = UIScreen.main.bounds.height
+        newSize.height = screenHeight * 0.11 // 화면 높이의 10%로 고정
         return newSize
     }
 

--- a/Sodam/Sodam/Main/View/MainMessages.swift
+++ b/Sodam/Sodam/Main/View/MainMessages.swift
@@ -7,6 +7,32 @@
 
 import Foundation
 
-enum MainMessages: CaseIterable {
-    // 랜덤 문구 정의할 예정
+enum MainMessages: String, CaseIterable {
+    case message1 = "행복은 먼 곳에 있지 않아요. 지금 이 순간에 왔을지도요."
+    case message2 = "작은 것에 감사할 줄 알 때, 큰 행복이 찾아온답니다."
+    case message3 = "당신은 이미 충분히 빛나는 전구 같은 사람!"
+    case message4 = "웃음은 마음의 태양이죠. 오늘도 환하게 웃어보기!"
+    case message5 = "당신이 라면만 먹어도 행복하다면 그게 행복이에요."
+    case message6 = "좋은 생각이 좋은 하루를 만들어준답니다."
+    case message7 = "오늘 하루, 고생 많았어요. 화이팅"
+    case message8 = "작은 친절 하나가 소소한 행복을 만듭니다."
+    case message9 = "행복은 길 위에 놓인 작은 꽃과 같습니다. 걸음을 멈추고 둘러보아요."
+    case message10 = "당신이 사랑받고 있다는 사실을 잊지 말기."
+    case message11 = "소소한 행복은 목적지가 아니라 여정입니다."
+    case message12 = "어제보다 나은 오늘, 그것이 행복이죠. 별거 있나요?"
+    case message13 = "소소한 행복은 언제나 당신 곁에 있어요."
+    case message14 = "작은 성공을 축하하는 건 큰 행복의 시작이랍니다."
+    case message15 = "행복은 다른 사람의 미소를 보는 데서 시작될 수 있답니다."
+    case message16 = "당신의 마음속엔 이미 행복의 씨앗이 있네요."
+    case message17 = "힘들 때일수록 스스로를 응원해주세요. 행복은 당신을 기다립니다."
+    case message18 = "행복은 완벽함이 아닌, 불완전함을 사랑하는 마음에서 오는 것."
+    case message19 = "자신을 소중히 여길 때, 행복은 더 자주 찾아온답니다."
+    case message20 = "지금 느끼는 감사가 내일의 행복을 만들어줄거에요"
+    
+    static let firstMessage = "소소하고 확실한 행복으로 행담이를 깨워볼까요?"
+    
+    // 랜덤으로 메세지 반환하기 (firstMessage는 제외하기)
+    static func getRandomMessage() -> String {
+        return Self.allCases.filter { $0.rawValue != firstMessage }.randomElement()?.rawValue ?? "오늘의 소확행 기록하기."
+    }
 }

--- a/Sodam/Sodam/Main/View/MainMessages.swift
+++ b/Sodam/Sodam/Main/View/MainMessages.swift
@@ -33,6 +33,6 @@ enum MainMessages: String, CaseIterable {
     
     // 랜덤으로 메세지 반환하기 (firstMessage는 제외하기)
     static func getRandomMessage() -> String {
-        return Self.allCases.filter { $0.rawValue != firstMessage }.randomElement()?.rawValue ?? "오늘의 소확행 기록하기."
+        return Self.allCases.randomElement()?.rawValue ?? "오늘의 소확행 기록하기."
     }
 }

--- a/Sodam/Sodam/Main/View/MainView.swift
+++ b/Sodam/Sodam/Main/View/MainView.swift
@@ -8,9 +8,9 @@
 import UIKit
 import SnapKit
 
-class MainView: UIView {
+final class MainView: UIView {
     // 이미지 뷰
-    private let circularImageView: UIImageView = {
+    public let circularImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.image = UIImage(systemName: "star.fill")
         imageView.contentMode = .scaleAspectFit
@@ -18,9 +18,7 @@ class MainView: UIView {
         imageView.backgroundColor = .imageBackground
         
         // 원형 스타일
-        imageView.layer.cornerRadius = 150
         imageView.layer.masksToBounds = true
-        
         return imageView
     }()
     // 라벨 뷰
@@ -31,7 +29,6 @@ class MainView: UIView {
         label.font = .mapoGoldenPier(14)
         label.numberOfLines = 0
         label.textColor = .darkGray
-        
         return label
     }()
     // 버튼 뷰
@@ -42,7 +39,6 @@ class MainView: UIView {
         button.titleLabel?.font = .mapoGoldenPier(20)
         button.backgroundColor = .buttonBackground
         button.layer.cornerRadius = 15
-        
         return button
     }()
     
@@ -67,11 +63,12 @@ class MainView: UIView {
         circularImageView.snp.makeConstraints {
             $0.top.equalTo(safeAreaLayoutGuide.snp.top).offset(UIScreen.main.bounds.height * 0.15) // 화면 높이의 15%로 높이를 맞춤
             $0.centerX.equalToSuperview()
-            $0.width.height.equalTo(300)
+            $0.width.equalToSuperview().multipliedBy(0.7)
+            $0.height.equalTo(circularImageView.snp.width)
         }
         
         messageLabel.snp.makeConstraints {
-            $0.top.equalTo(circularImageView.snp.bottom).offset(30)
+            $0.top.equalTo(circularImageView.snp.bottom).offset(40)
             $0.centerX.equalToSuperview()
             $0.width.equalToSuperview().multipliedBy(0.85)
         }
@@ -82,5 +79,15 @@ class MainView: UIView {
             $0.height.equalTo(60)
             $0.width.equalToSuperview().multipliedBy(0.85)
         }
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        circularImageView.layer.cornerRadius = circularImageView.frame.width / 2
+    }
+    
+    // 메세지라벨
+    public func updateMessage(_ message: String) {
+        messageLabel.text = message
     }
 }

--- a/Sodam/Sodam/Main/ViewModel/CustomTabBarController.swift
+++ b/Sodam/Sodam/Main/ViewModel/CustomTabBarController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class CustomTabBarController: UITabBarController {
+final class CustomTabBarController: UITabBarController {
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Sodam/Sodam/Main/ViewModel/MainViewController.swift
+++ b/Sodam/Sodam/Main/ViewModel/MainViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class MainViewController: UIViewController {
+final class MainViewController: UIViewController {
     
     private let mainView = MainView()
     

--- a/Sodam/Sodam/Main/ViewModel/MainViewController.swift
+++ b/Sodam/Sodam/Main/ViewModel/MainViewController.swift
@@ -11,13 +11,42 @@ final class MainViewController: UIViewController {
     
     private let mainView = MainView()
     
+    // 처음 클릭 여부 확인
+    private var isFirstTap = true
+    
     override func loadView() {
         self.view = mainView
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+        configureFirstMessage()
+        addGesture()
     }
     
+    private func configureFirstMessage() {
+        // 앱 초기 실행 시 첫번째 문구 설정
+        mainView.updateMessage(MainMessages.firstMessage)
+    }
+    
+    private func addGesture() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(imageViewTap))
+        mainView.circularImageView.addGestureRecognizer(tapGesture)
+        mainView.circularImageView.isUserInteractionEnabled = true
+    }
+    
+    @objc private func imageViewTap() {
+        // 연속 클릭 방지
+        mainView.circularImageView.isUserInteractionEnabled = false // 클릭 비활성화
+        
+        if isFirstTap {
+            isFirstTap = false // 첫번째 클릭 이후 상태 변경
+        }
+        mainView.updateMessage(MainMessages.getRandomMessage())
+        
+        // 2초 후 다시 활성화
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+            self.mainView.circularImageView.isUserInteractionEnabled = true // 클릭 재활성화
+        }
+    }
 }


### PR DESCRIPTION
## 1. 요약 
전 pr에서 받은 피드백 ( 오타 수정, class 앞에 final 붙이기, 메인화면 이미지뷰 동적으로 만들기) 수정 완료했습니다.

1. 문구는 앱 실행 처음에만 firstMessage 가 나오고 나머지 20개의 문장이 랜덤으로 나옵니다.

2. 중복 클릭 방지 코드를 넣었습니다.


## 2. 스크린샷 
![화면 기록 2025-01-22 오전 9 46 54](https://github.com/user-attachments/assets/b815a5f6-4cb8-4fa9-b166-7214f2a04e71)

## 3. 공유사항

이미지뷰를 처음 눌렀을 때 초기 Bool 값을 true로 두다가 터치 후에 false가 되면 기존 랜덤문구들이 나오게 했는데  나중에는 알이 부화되었는지의 여부로 저걸 변경할 예정입니다. ( 안그러면 처음 들어올 때마다  firstMessage 가 나와서)

그리고 여러번 버튼을 눌러서 빠르게 변환되지 않게 한번 이미지뷰를 탭하면 2초간 탭할 수 없게 비활성화 시켜서 앱이 불필요한 작업을 반복하지 않게 했습니다.

#### 다음 할 일.

- 모달 띄우는 기능
- 최초 작성 클릭 시 알럿 설정

