### PR TITLE
[Refactor] 행담이 보관함 뷰 UI 업데이트 및 Navigation 추가

### DIFF
--- a/Sodam/Sodam/HangdamStatusView.swift
+++ b/Sodam/Sodam/HangdamStatusView.swift
@@ -14,7 +14,7 @@ struct HangdamStatusView: View {
     @Binding var mockHangdam: MockHangdam
     
     var body: some View {
-        HStack(alignment: .center, spacing: 16) {
+        HStack(alignment: .center, spacing: 20) {
             Image(.babyHangdam)
                 .resizable()
                 .aspectRatio(contentMode: .fit)
@@ -24,11 +24,11 @@ struct HangdamStatusView: View {
             
             VStack(alignment: .leading, spacing: 10) {
                 Text(mockHangdam.name)
-                    .font(.mapoGoldenPier(24))
+                    .font(.maruburiot(type: .bold, size: 25))
                 Text("Lv.\(mockHangdam.level) 애기 행담이")
-                    .font(.mapoGoldenPier(18))
+                    .font(.maruburiot(type: .semiBold, size: 18))
                 Text("\(mockHangdam.startDate?.toString ?? "") ~")
-                    .font(.mapoGoldenPier(17))
+                    .font(.maruburiot(type: .regular, size: 16))
             }
             .foregroundStyle(Color(uiColor: .white))
         }

--- a/Sodam/Sodam/HangdamStatusView.swift
+++ b/Sodam/Sodam/HangdamStatusView.swift
@@ -18,6 +18,7 @@ struct HangdamStatusView: View {
             Image(.babyHangdam)
                 .resizable()
                 .aspectRatio(contentMode: .fit)
+                .frame(width: size.width / 3)
                 .background(Color.imageBackground)
                 .clipShape(.circle)
             

--- a/Sodam/Sodam/HangdamStorage/HangdamGridView.swift
+++ b/Sodam/Sodam/HangdamStorage/HangdamGridView.swift
@@ -30,7 +30,7 @@ fileprivate struct HangdamGrid: View {
     @Binding var mockHangdam: MockHangdam
     
     var body: some View {
-        VStack {
+        VStack(spacing: 1) {
             Image(.babyHangdam)
                 .resizable()
                 .aspectRatio(contentMode: .fit)
@@ -38,13 +38,15 @@ fileprivate struct HangdamGrid: View {
                 .clipShape(.rect(cornerRadius: 15))
                 .padding()
             
-            VStack(alignment: .leading, spacing: 5) {
+            VStack(alignment: .leading, spacing: 8) {
                 Text(mockHangdam.name)
+                    .font(.maruburiot(type: .bold, size: 16))
+                    .foregroundStyle(Color(uiColor: .darkGray))
                 
                 Text(mockHangdam.startDate?.toString ?? "")
+                    .font(.maruburiot(type: .regular, size: 14))
+                    .foregroundStyle(Color(uiColor: .gray))
             }
-            .font(.mapoGoldenPier(15))
-            .foregroundStyle(Color(uiColor: .darkGray))
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding([.leading, .bottom])
         }

--- a/Sodam/Sodam/HangdamStorage/HangdamGridView.swift
+++ b/Sodam/Sodam/HangdamStorage/HangdamGridView.swift
@@ -30,28 +30,32 @@ fileprivate struct HangdamGrid: View {
     @Binding var mockHangdam: MockHangdam
     
     var body: some View {
-        VStack(spacing: 1) {
-            Image(.babyHangdam)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .background(Color.imageBackground)
-                .clipShape(.rect(cornerRadius: 15))
-                .padding()
-            
-            VStack(alignment: .leading, spacing: 8) {
-                Text(mockHangdam.name)
-                    .font(.maruburiot(type: .bold, size: 16))
-                    .foregroundStyle(Color(uiColor: .darkGray))
+        NavigationLink {
+            TestView(hangdam: $mockHangdam)
+        } label: {
+            VStack(spacing: 1) {
+                Image(.babyHangdam)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .background(Color.imageBackground)
+                    .clipShape(.rect(cornerRadius: 15))
+                    .padding()
                 
-                Text(mockHangdam.startDate?.toString ?? "")
-                    .font(.maruburiot(type: .regular, size: 14))
-                    .foregroundStyle(Color(uiColor: .gray))
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(mockHangdam.name)
+                        .font(.maruburiot(type: .bold, size: 16))
+                        .foregroundStyle(Color(uiColor: .darkGray))
+                    
+                    Text(mockHangdam.startDate?.toString ?? "")
+                        .font(.maruburiot(type: .regular, size: 14))
+                        .foregroundStyle(Color(uiColor: .gray))
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding([.leading, .bottom])
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding([.leading, .bottom])
+            .background(Color.cellBackground)
+            .clipShape(.rect(cornerRadius: 15))
         }
-        .background(Color.cellBackground)
-        .clipShape(.rect(cornerRadius: 15))
     }
 }
 

--- a/Sodam/Sodam/HangdamStorage/HangdamStorageView.swift
+++ b/Sodam/Sodam/HangdamStorage/HangdamStorageView.swift
@@ -32,7 +32,7 @@ struct HangdamStorageView: View {
             .padding(.top)
             .padding(.horizontal)
         }
-        
+        .background(Color.viewBackground)
     }
 }
 

--- a/Sodam/Sodam/HangdamStorage/HangdamStorageView.swift
+++ b/Sodam/Sodam/HangdamStorage/HangdamStorageView.swift
@@ -12,27 +12,34 @@ struct HangdamStorageView: View {
     @State var mockHangdam: MockHangdam = .mockHangdam
     
     var body: some View {
-        GeometryReader { geometry in
-            VStack(alignment: .center) {
-                HangdamStatusView(size: geometry.size, mockHangdam: $mockHangdam)
-                    .clipShape(.rect(cornerRadius: 15))
-                
-                Text("행담이 보관함")
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .font(.mapoGoldenPier(27))
-                    .foregroundStyle(Color.textAccent)
-                    .padding(.top)
-                
-                ScrollView {
-                    HangdamGridView(mockHangdam: $mockHangdam)
-                        .padding(.bottom)
+        NavigationStack {
+            GeometryReader { geometry in
+                VStack(alignment: .center) {
+                    NavigationLink {
+                        TestView(hangdam: $mockHangdam)
+                    } label: {
+                        HangdamStatusView(size: geometry.size, mockHangdam: $mockHangdam)
+                            .clipShape(.rect(cornerRadius: 15))
+                    }
+                    
+                    Text("행담이 보관함")
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .font(.mapoGoldenPier(27))
+                        .foregroundStyle(Color.textAccent)
+                        .padding(.top)
+                    
+                    ScrollView {
+                        HangdamGridView(mockHangdam: $mockHangdam)
+                            .padding(.bottom)
+                    }
+                    .scrollIndicators(.hidden)
                 }
-                .scrollIndicators(.hidden)
+                .padding(.top)
+                .padding(.horizontal)
             }
-            .padding(.top)
-            .padding(.horizontal)
+            .background(Color.viewBackground)
         }
-        .background(Color.viewBackground)
+        .tint(.textAccent)
     }
 }
 

--- a/Sodam/Sodam/HangdamStorage/MockHangdam.swift
+++ b/Sodam/Sodam/HangdamStorage/MockHangdam.swift
@@ -26,7 +26,8 @@ struct MockHangdam {
     static let mockHangdam = MockHangdam(name: "멍담이", startDate: Date.now - 86400, endDate: nil)
 }
 
-struct MockHappiness {
+struct MockHappiness: Identifiable {
+    let id: UUID = .init()
     var imagePaths: [String]?
     let content: String
     let tag: Tag?

--- a/Sodam/Sodam/HangdamStorage/TestView.swift
+++ b/Sodam/Sodam/HangdamStorage/TestView.swift
@@ -1,0 +1,28 @@
+//
+//  TestView.swift
+//  Sodam
+//
+//  Created by EMILY on 24/01/2025.
+//
+
+import SwiftUI
+
+struct TestView: View {
+    
+    @Binding var hangdam: MockHangdam
+    
+    var body: some View {
+        VStack {
+            Text("\(hangdam.name)가 담은 기억들")
+            ForEach(hangdam.happiness) { happiness in
+                Text(happiness.content)
+            }
+        }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color.viewBackground)
+    }
+}
+
+#Preview {
+    TestView(hangdam: .constant(.mockHangdam))
+}


### PR DESCRIPTION
## 1. 요약
- viewBackground color 추가
- 행담이 상태뷰에서 행담이 이미지 크기 줄임
- font set 마루부리로 바꾸고 굵기 별로 지정
- 자잘한 간격 수정
- 행담이 상태뷰 및 행담이 grid에 `NavigationLink` 적용 : `TestView` 사용
## 2. 스크린샷 
| before | after |
| ----- | ----- |
| <img src="https://github.com/user-attachments/assets/f6db7713-763b-47a9-bb5f-2034f3730867" width=430> | <img src="https://github.com/user-attachments/assets/d164c12d-8bf5-4f5f-92e7-919d50f2cab5" width=430> |

![Screen Recording 2025-01-24 at 04 47 06](https://github.com/user-attachments/assets/5388b2d7-4e7c-43d9-922b-26e754a20311)

## 3. 공유사항
데이터 바인딩 및 행담이 기억 리스트 뷰 merge 시 코드 수정 필요