### PR TITLE
[Fix] 컴파일 에러 해결

### DIFF
--- a/Sodam/Sodam/HappinessList/HappinessListView.swift
+++ b/Sodam/Sodam/HappinessList/HappinessListView.swift
@@ -41,7 +41,7 @@ struct HappinessListView: View {
                                             .font(.mapoGoldenPier(FontSize.body))
                                             .lineLimit(2)
                                             .frame(height: 50, alignment: .topLeading)
-                                        Text("\(mockHangdam.startDate?.toString ?? "")")
+                                        Text("\(mockHangdam.startDate?.toFormattedString ?? "")")
                                             .font(.mapoGoldenPier(FontSize.timeStamp))
                                             .foregroundStyle(.gray)
                                     }


### PR DESCRIPTION
## 1. 요약
무능력한 `Xcode`가 잡아내지 못하고 원인 불명 컴파일 에러만 내고 있었으나 +Date 의 계산 프로퍼티 네이밍 변경이 반영이 되지 않은 것이 원인인 것을 발견하고 고침
## 2. 스크린샷
- 에러 메시지
![Screenshot 2025-01-24 at 12 05 18](https://github.com/user-attachments/assets/0ab8c771-b920-48ee-ba98-2281108139ad)
- 실제 원인
![Screenshot 2025-01-24 at 12 05 54](https://github.com/user-attachments/assets/fe45b31b-b938-4cd0-9f62-5cb93459d3c8)
![Screenshot 2025-01-24 at 12 06 11](https://github.com/user-attachments/assets/9eec16f9-39de-4ce7-94ba-0467b67d09e7)
> `toString` - `toFormattedString`으로 변경된 내용을 반영하지 않고 있었음. 이 부분을 캐치하지 못하고 타입 체크가 안된다는 컴파일 에러만 떠서 혼란스러웠던 상황
## 3. 공유사항
