### PR TITLE
[Feat] 글 임시저장 및 작성 완료 기능 구현

### DIFF
--- a/Sodam/Sodam/Manager/UserDefaultsManager.swift
+++ b/Sodam/Sodam/Manager/UserDefaultsManager.swift
@@ -35,7 +35,7 @@ final class UserDefaultsManager {
         userDefaults.set(content, forKey: Keys.content)
     }
     
-    func saveImagePath(_ imagePath: String) {
+    func saveImagePath(_ imagePath: [String]) {
         userDefaults.set(imagePath, forKey: Keys.imagePath)
     }
     
@@ -53,7 +53,14 @@ final class UserDefaultsManager {
         userDefaults.string(forKey: Keys.content)
     }
     
-    func getImagePath() -> String? {
-        userDefaults.string(forKey: Keys.imagePath)
+    func getImagePath() -> [String]? {
+        userDefaults.stringArray(forKey: Keys.imagePath)
     }
+    
+    func deleteTemporaryPost() {
+        print("deleteTemporaryPost 호출")
+        userDefaults.removeObject(forKey: Keys.content)
+        userDefaults.removeObject(forKey: Keys.imagePath)
+    }
+    
 }

--- a/Sodam/Sodam/WriteView/WriteModel.swift
+++ b/Sodam/Sodam/WriteView/WriteModel.swift
@@ -38,11 +38,20 @@ final class WriteModel {
     
     // 이미지 추가 메서드
     func addImage(_ image: UIImage) {
+        // 사진이 두 장 이상 있을 경우 추가되지 않게 하기
+        guard post.images.count < 1 else {
+            return
+        }
         post.images.append(image)
     }
     
     // 이미지 삭제 메서드
     func removeImage(at index: Int) {
         post.images.remove(at: index)
+    }
+    
+    // post 초기화 메서드(작성 완료시 호출)
+    func resetPost() {
+        post = Post(content: "", images: [])
     }
 }

--- a/Sodam/Sodam/WriteView/WriteViewController.swift
+++ b/Sodam/Sodam/WriteView/WriteViewController.swift
@@ -170,13 +170,14 @@ final class WriteViewController: UIViewController {
     
     // 이미지 버튼 탭할 때 호출되는 메서드
     @objc private func addImage() {
+        // 이미지 첨부 상한에 도달하면 알림 보내기(현재는 1개)
+        guard writeViewModel.images.count < 1 else {
+            showAlertMaxImageLimitReached()
+            return
+        }
+        
         writeViewModel.requestPhotoLibraryAccess { [weak self] isGranted in
             if isGranted {
-                // 이미지 첨부 상한에 도달하면 알림 보내기(현재는 1개)
-                guard self?.writeViewModel.images.count ?? 0 < 1 else {
-                    self?.showAlertMaxImageLimitReached()
-                    return
-                }
                 // 사진 라이브러리 권한이 허용된 경우 사진 피커 생성 및 표시
                 let photoPicker = self?.writeViewModel.createPhotoPicker()
                 if let picker = photoPicker {

--- a/Sodam/Sodam/WriteView/WriteViewController.swift
+++ b/Sodam/Sodam/WriteView/WriteViewController.swift
@@ -148,6 +148,12 @@ final class WriteViewController: UIViewController {
     
     // 카메라 버튼 탭할 때 호출되는 메서드
     @objc private func openCamera() {
+        // 이미지 첨부 상한에 도달하면 알림 보내기(현재는 1개)
+        guard writeViewModel.images.count < 1 else {
+            showAlertMaxImageLimitReached()
+            return
+        }
+        
         writeViewModel.requestCameraAccess { [weak self] isGranted in
             if isGranted {
                 // 카메라 권한이 허용된 경우 카메라 생성 및 표시
@@ -237,6 +243,8 @@ final class WriteViewController: UIViewController {
             self.present(alertControlelr, animated: true)
         }
     }
+    
+    // MARK: - Alert 메서드
     
     // 이미지 상한을 알리는 Alert 표시
     private func showAlertMaxImageLimitReached() {

--- a/Sodam/Sodam/WriteView/WriteViewModel.swift
+++ b/Sodam/Sodam/WriteView/WriteViewModel.swift
@@ -145,19 +145,21 @@ final class WriteViewModel: NSObject {
 
 // MARK: - 이미지 임시저장, 불러오기 메서드
 extension WriteViewModel {
+    // 이미지 경로 생성 및 파일매니저에 저장하기 위한 메서드
     private func saveImages(_ images: [UIImage]) -> [String] {
         var imagePaths: [String] = []
         
         for image in images {
-            let imagePath = imageManager.nameImagePath()
-            imageManager.saveImage(image, with: imagePath)
+            let imagePath = imageManager.nameImagePath() // ImageManager의 nameImagePath 호출
+            imageManager.saveImage(image, with: imagePath) // ImageManager의 saveImage 호출
             imagePaths.append(imagePath)
         }
         
+        // 임시 저장과 영구 저장에서 사용할 imagePath 배열 반환
         return imagePaths
     }
     
-    
+    // 임시 저장을 위한 메서드
     func saveTemporaryPost() {
         let imagePaths = saveImages(writeModel.post.images)
         
@@ -165,17 +167,21 @@ extension WriteViewModel {
         UserDefaultsManager.shared.saveImagePath(imagePaths)
     }
     
+    // 임시 저장된 글 불러오는 메서드
     func loadTemporaryPost() {
-        guard let content = UserDefaultsManager.shared.getContent(),
-              let imagePaths = UserDefaultsManager.shared.getImagePath()
+        guard let content = UserDefaultsManager.shared.getContent(), // 임시 저장된 글 불러오기
+              let imagePaths = UserDefaultsManager.shared.getImagePath() // 임시 저장된 이미지 경로 불러오기
         else {
+            // 불러올 데이터가 없는 경우 종료
             return
         }
         
+        // 불러온 글 내용을 모델에 업데이트
         writeModel.updateText(content)
         
         for imagePath in imagePaths {
-            if let result = imageManager.getImage(with: imagePath) {
+            if let result = imageManager.getImage(with: imagePath) { // ImageManager의 getImage 호출해서 이미지 불러오기
+                // 뷰에 이미지 추가
                 writeModel.addImage(result)
             }
         }


### PR DESCRIPTION
## 1. 요약 
글 작성 취소시 UserDefaults에 임시 저장, 작성 완료시 CoreData 영구 저장하도록 하였습니다.

## 2. 스크린샷 

| <img src="https://github.com/user-attachments/assets/f30754d1-9061-407a-ab9a-ce074a3b11ff" alt="임시저장 테스트" width="200"> | <img src="https://github.com/user-attachments/assets/e8e0912f-ee90-4f51-b202-a06ef87bee0e" alt="작성 완료 테스트" width="200"> | <img src="https://github.com/user-attachments/assets/08035b62-6e85-4eb9-b72f-4e12519a0183" alt="사진 추가 알럿 테스트" width="200">
|-------------------------------------------------------|-------------------------------------------------------|-------------------------------------------------------|
임시 저장 테스트 | 작성 완료 테스트 | 사진 추가 제한 알럿



## 3. 공유사항
- UserDefaultsManager에 ImagePath 저장 하는 부분 코어데이터와 같게 배열로 변경하였습니다. (여기서 혹시 문제 되는 부분 있는지 확인 필요할 것 같습니다!)
- 작성 완료시 UserDefaults에 저장된 내용을 비우기 위해 UserDefaultsManager에 deleteTemporaryPost 추가했습니다.
- 이미지를 배열로 받지만 일단 한 장만 추가되도록 제한을 두고, Alert을 띄워 더이상 추가될 수 없음을 알리도록 하였습니다.
- WriteViewModel에 isPostSubmitted 플래그 변수를 추가해 모달이 dismiss 됐을때, 작성 완료인지 취소인지 구분하도록 했습니다.
- 카메라로 이미지 추가하는 것도 하나 이상 추가 안되게 한다고 했는데, 실제로 되는지는 테스트 해봐야 합니다..!
