### PR TITLE
[Feat] NotificationCenter로 레벨업 이벤트 전달

### DIFF
--- a/Sodam/Sodam/Extension/+Notification.swift
+++ b/Sodam/Sodam/Extension/+Notification.swift
@@ -1,0 +1,12 @@
+//
+//  +Notification.swift
+//  Sodam
+//
+//  Created by EMILY on 27/01/2025.
+//
+
+import Foundation
+
+extension Notification {
+    static let levelUP = Notification.Name("levelUP")
+}

--- a/Sodam/Sodam/Main/View/MainViewModel.swift
+++ b/Sodam/Sodam/Main/View/MainViewModel.swift
@@ -5,6 +5,7 @@
 //  Created by 박진홍 on 1/26/25.
 //
 
+import Foundation
 import Combine
 
 final class MainViewModel: ObservableObject {
@@ -18,6 +19,9 @@ final class MainViewModel: ObservableObject {
         self.hangdamRepository = repository
         self.name = hangdamRepository.getCurrentHangdam().name
         self.updateMessage() // 초기화 시 메세지 업데이트
+        
+        // 행담이 레벨업 할때마다 특정 메시지를 보여주기 위해 observing
+        NotificationCenter.default.addObserver(self, selector: #selector(updateMessageWhenLevelUp), name: Notification.levelUP, object: nil)
     }
     
     func setGif() {
@@ -45,5 +49,22 @@ final class MainViewModel: ObservableObject {
     
     func getCurrentHangdamID() -> String {
         return hangdamRepository.getCurrentHangdam().id
+    }
+    
+    @objc func updateMessageWhenLevelUp(notification: Notification) {
+        guard let userInfo = notification.userInfo,
+              let level = userInfo["level"] as? Int
+        else { return }
+        
+        /// 디버깅
+        print("행담이 레벨 \(level)로 성장함")
+        
+        // TODO: 레벨에 따라 다른 메시지 설정
+        // MARK: 레벨에 따라 gif 설정하는 것도 여기서 하면 좋을 듯 (setGif 구현 여기로 옮기기)
+    }
+    
+    /// deinit 시 observing 해제
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 }

--- a/Sodam/Sodam/Repository/HappinessRepository.swift
+++ b/Sodam/Sodam/Repository/HappinessRepository.swift
@@ -30,7 +30,7 @@ final class HappinessRepository {
         coreDataManager.createHappiness(happiness, to: hangdamID)
     }
     
-    /// 행담이 레벨이 0이거나 기억이 30개째가 될 경우 startDate 또는 endDate 업데이트
+    /// 행담이가 가진 기존 행복 개수 체크하여 경우에 따라 이벤트 발생 또는 데이터 업데이트
     private func updateHangdamIfNeeded(hangdamID: String) {
         guard let hangdamID = IDConverter.toNSManagedObjectID(from: hangdamID, in: coreDataManager.context),
               let count = coreDataManager.checkHappinessCount(with: hangdamID)
@@ -40,10 +40,18 @@ final class HappinessRepository {
         }
         
         switch count {
-        case 0:
+        case 0:     // 행담이 startDate 업데이트, 레벨 1로 성장
             coreDataManager.updateHangdam(with: hangdamID, updateCase: .startDate(Date.now))
-        case 29:
+            postNotification(level: 1)
+        case 3:     // 행담이 레벨 2로 성장
+            postNotification(level: 2)
+        case 10:    // 행담이 레벨 3으로 성장
+            postNotification(level: 3)
+        case 24:    // 행담이 레벨 4로 성장
+            postNotification(level: 4)
+        case 29:    // 행담이 endDate 업데이트, 최종 성장(보관함 이동)
             coreDataManager.updateHangdam(with: hangdamID, updateCase: .endDate(Date.now))
+            postNotification(level: 5)
         default:
             return
         }
@@ -61,5 +69,11 @@ final class HappinessRepository {
         guard let id = IDConverter.toNSManagedObjectID(from: id, in: coreDataManager.context) else { return }
         
         coreDataManager.deleteHappiness(with: id)
+    }
+}
+
+extension HappinessRepository {
+    private func postNotification(level: Int) {
+        NotificationCenter.default.post(name: Notification.levelUP, object: nil, userInfo: ["level": level])
     }
 }


### PR DESCRIPTION
## 1. 요약
`WriteView`에서 행복이 작성완료가 되는 시점에 레벨업 순간인지 체크하고 레벨업 할 때 `MainView`에 알려주는 이벤트 구현
## 2. 스크린샷 
## 3. 공유사항
- `HappinessRepository`에서 행복 개수를 검사하여 `Notification`을 `post`하고, `MainViewModel`에서 `observe` 합니다.
- 레벨업 이벤트와 함께 레벨 몇으로 성장하는지 `Int` 값을 함께 전달합니다.
- `MainViewModel`에서 `level` 값을 활용하여 레벨에 따라 메시지가 나오도록 처리하시면 될 거 같습니다.
- 추가로, 레벨에 따라 gif 변하는 로직을 여기서 함께 처리하도록 옮기는 것도 괜찮겠다는 생각이 들었습니다.