### PR TITLE
[Feat] 행담이 레벨별 성장 위해서 행담엔티티 코어데이터에 level 추가 후 레벨별 진화 메세지 추가

### DIFF
--- a/Sodam/Sodam/CoreData/CoreDataManager.swift
+++ b/Sodam/Sodam/CoreData/CoreDataManager.swift
@@ -82,6 +82,8 @@ final class CoreDataManager {
             entity.startDate = date
         case .endDate(let date):
             entity.endDate = date
+        case .level(let level):
+            entity.level = Int16(level)
         }
 
         print("[CoreData] 행담이 정보 업데이트 완료")

--- a/Sodam/Sodam/CoreData/HangdamUpdateCase.swift
+++ b/Sodam/Sodam/CoreData/HangdamUpdateCase.swift
@@ -12,4 +12,5 @@ enum HangdamUpdateCase {
     case name(String)
     case startDate(Date)
     case endDate(Date)
+    case level(Int)
 }

--- a/Sodam/Sodam/CoreData/SodamContainer.xcdatamodeld/SodamContainer.xcdatamodel/contents
+++ b/Sodam/Sodam/CoreData/SodamContainer.xcdatamodeld/SodamContainer.xcdatamodel/contents
@@ -2,6 +2,7 @@
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="24C101" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
     <entity name="HangdamEntity" representedClassName="HangdamEntity" syncable="YES" codeGenerationType="class">
         <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="level" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="name" optional="YES" attributeType="String"/>
         <attribute name="startDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <relationship name="happinesses" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="HappinessEntity" inverseName="hangdam" inverseEntity="HappinessEntity"/>

--- a/Sodam/Sodam/Main/View/MainMessages.swift
+++ b/Sodam/Sodam/Main/View/MainMessages.swift
@@ -40,4 +40,23 @@ enum MainMessages: String, CaseIterable {
         // 쉼표를 기준으로 줄바꿈 추가
         let formattedMessage = randomMessage.replacingOccurrences(of: ",", with: ",\n")
         return formattedMessage
-    }}
+    }
+    
+    // 레벨 별 메세지
+    static func getLevelUpMessage(level: Int, name: String) -> String {
+        switch level {
+        case 1:
+            return "드디어 알을 깨고 아기 \(name)(이)가 눈을 마주치네요!"
+        case 2:
+            return "하트 윙크 발사하는 사랑스러운 \(name)(이)로 성장했네요!"
+        case 3:
+            return "주황 목도리를 하고 어엿한 \(name)(이)로 성장 완료!"
+        case 4:
+            return "소확행을 좋아하는 \(name)(이)에게 행복한 기억을 더 줘볼까요?"
+        case 5: // 마지막 메시지
+            return "\(name)(이)가 당신의 소확행을 배부르게 먹고 보관되었습니다. 다음엔 누가 나올까요?"
+        default:
+            return "행복한 성장이 진행 중입니다!"
+        }
+    }
+}

--- a/Sodam/Sodam/Main/View/MainViewController.swift
+++ b/Sodam/Sodam/Main/View/MainViewController.swift
@@ -104,8 +104,8 @@ final class MainViewController: UIViewController {
         // 연속 클릭 방지
         mainView.circularImageView.isUserInteractionEnabled = false             // 클릭 비활성화
         
-        // 저정된 이름 유무에 따라서 메세지 업데이트
-        viewModel.updateMessage()
+        // 랜덤 메세지 강제 업데이트
+        viewModel.updateMessage(force:  true)
         
         // 2초 후 다시 활성화
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {

--- a/Sodam/Sodam/Main/View/MainViewModel.swift
+++ b/Sodam/Sodam/Main/View/MainViewModel.swift
@@ -17,10 +17,11 @@ final class MainViewModel: ObservableObject {
     
     init(repository: HangdamRepository = HangdamRepository()) {
         self.hangdamRepository = repository
-        self.name = hangdamRepository.getCurrentHangdam().name
-        self.updateMessage() // 초기화 시 메세지 업데이트
+        let currentHangdam = hangdamRepository.getCurrentHangdam()
+        self.name = currentHangdam.name
+        self.gifName = "phase\(currentHangdam.level)" // 현재 레벨에 맞는 GIF 설정
+        self.updateMessage()
         
-        // 행담이 레벨업 할때마다 특정 메시지를 보여주기 위해 observing
         NotificationCenter.default.addObserver(self, selector: #selector(updateMessageWhenLevelUp), name: Notification.levelUP, object: nil)
     }
     
@@ -37,7 +38,14 @@ final class MainViewModel: ObservableObject {
         setGif()
     }
     
-    func updateMessage() {
+    func updateMessage(force: Bool = false) {
+        if !force { // 강제 업데이트가 아닌 경우 기존 메시지가 비어 있는지 확인
+            guard message.isEmpty else {
+                print("updateMessage: 이미 메시지가 설정되어 있음. 덮어쓰지 않음.")
+                return
+            }
+        }
+        
         if let _ = name {
             message = MainMessages.getRandomMessage()
             print("이름이 지어졌음. 랜덤 메시지 표시")
@@ -53,14 +61,17 @@ final class MainViewModel: ObservableObject {
     
     @objc func updateMessageWhenLevelUp(notification: Notification) {
         guard let userInfo = notification.userInfo,
-              let level = userInfo["level"] as? Int
-        else { return }
+              let level = userInfo["level"] as? Int,
+              let currentName = name
+        else {
+            print("updateMessageWhenLevelUp: Notification 정보 누락")
+            return
+        }
+        message = MainMessages.getLevelUpMessage(level: level, name: currentName)
+        gifName = "phase\(level)"
         
-        /// 디버깅
-        print("행담이 레벨 \(level)로 성장함")
-        
-        // TODO: 레벨에 따라 다른 메시지 설정
-        // MARK: 레벨에 따라 gif 설정하는 것도 여기서 하면 좋을 듯 (setGif 구현 여기로 옮기기)
+        // 디버깅
+        print("행담이 레벨 \(level)로 성장함. 메시지 업데이트: \(message)")
     }
     
     /// deinit 시 observing 해제

--- a/Sodam/Sodam/Repository/HappinessRepository.swift
+++ b/Sodam/Sodam/Repository/HappinessRepository.swift
@@ -24,6 +24,7 @@ final class HappinessRepository {
         }
         
         /// 날짜 업데이트 필요성 체크
+        print("createHappiness: updateHangdamIfNeeded 호출")
         updateHangdamIfNeeded(hangdamID: happiness.hangdamID)
         
         /// 기억생성
@@ -39,18 +40,25 @@ final class HappinessRepository {
             return
         }
         
+        print("updateHangdamIfNeeded: count=\(count)")
+        
         switch count {
-        case 0:     // 행담이 startDate 업데이트, 레벨 1로 성장
+        case 0:
             coreDataManager.updateHangdam(with: hangdamID, updateCase: .startDate(Date.now))
+            coreDataManager.updateHangdam(with: hangdamID, updateCase: .level(1))
             postNotification(level: 1)
-        case 3:     // 행담이 레벨 2로 성장
+        case 3:
+            coreDataManager.updateHangdam(with: hangdamID, updateCase: .level(2))
             postNotification(level: 2)
-        case 10:    // 행담이 레벨 3으로 성장
+        case 10:
+            coreDataManager.updateHangdam(with: hangdamID, updateCase: .level(3))
             postNotification(level: 3)
-        case 24:    // 행담이 레벨 4로 성장
+        case 24:
+            coreDataManager.updateHangdam(with: hangdamID, updateCase: .level(4))
             postNotification(level: 4)
-        case 29:    // 행담이 endDate 업데이트, 최종 성장(보관함 이동)
+        case 29:
             coreDataManager.updateHangdam(with: hangdamID, updateCase: .endDate(Date.now))
+            coreDataManager.updateHangdam(with: hangdamID, updateCase: .level(5)) // 최종 레벨 저장
             postNotification(level: 5)
         default:
             return


### PR DESCRIPTION
## 1. 요약 
- 행담이 레벨 저장을 위해서 엔티티에 level 추가 
- 레벨 2까지 진화 후에 뜨는 메세지가 잘 나오는 것 확인
- 레벨별 지정메세지가 나온 후 랜덤메세지가 뜨지 않는 현상으로 imageViewTap 메서드 실행될 때 랜덤메세지가 강제로 업데이트 되게끔 해서 메세지 잘 나오는 것 확인


## 2. 스크린샷 
레벨 0 -> 1 가는것과 1 -> 2로 가는 것 까지 스샷 찍었습니다

![화면 기록 2025-01-27 오후 8 33 28](https://github.com/user-attachments/assets/a9d6d8a5-cafb-446c-8162-49191865d280)


## 3. 공유사항
글 작성할때 모달뜰 때 뒷배경이 하얗게 되는건 왜그러는 걸까용.... 
