### PR TITLE
[Refactor] DTO를 이용해 컨트롤러와 뷰모델 바인딩 완료

### DIFF
--- a/Sodam/Sodam/CoreData/DTO/HangdamDTO.swift
+++ b/Sodam/Sodam/CoreData/DTO/HangdamDTO.swift
@@ -24,6 +24,9 @@ struct HangdamDTO {
         default: return 0       // 알담이 : 1개 작성 필요
         }
     }
+    var message: String {
+        return MainMessages.messageForLevel(level, name: name ?? "이름 없음")
+    }
 }
 
 extension HangdamEntity {

--- a/Sodam/Sodam/CoreData/DTO/HangdamDTO.swift
+++ b/Sodam/Sodam/CoreData/DTO/HangdamDTO.swift
@@ -24,9 +24,6 @@ struct HangdamDTO {
         default: return 0       // 알담이 : 1개 작성 필요
         }
     }
-    var message: String {
-        return MainMessages.messageForLevel(level, name: name ?? "이름 없음")
-    }
 }
 
 extension HangdamEntity {

--- a/Sodam/Sodam/Main/View/MainMessages.swift
+++ b/Sodam/Sodam/Main/View/MainMessages.swift
@@ -32,6 +32,23 @@ enum MainMessages: String, CaseIterable {
     // 첫번쨔 메세지는 별도로 관리
     static let firstMessage = "소소하고 확실한 행복으로 행담이를 깨워볼까요?"
     
+    static func messageForLevel(_ level: Int, name: String) -> String {
+        switch level {
+        case 1:
+            return "드디어 알을 깨고 아기 \(name)(이)가 눈을 마주치네요!"
+        case 2:
+            return "하트 윙크 발사하는 사랑스러운 \(name)로 변신했네요!"
+        case 3:
+            return "점잖스러운 \(name)로 변신 완료!"
+        case 4:
+            return "소확행을 좋아하는 \(name)에게 행복한 기억을 더 줘볼까요?"
+        case 5:
+            return "\(name)가 당신의 소확행을 배부르게 먹고 보관되었습니다. 다음엔 누가 나올까요?"
+        default:
+            return "행복의 새로운 단계를 향해 나아가고 있어요!"
+        }
+    }
+    
     // 랜덤으로 메세지 반환하기 (firstMessage는 제외하기)
     static func getRandomMessage() -> String {
         let randomMessages = Self.allCases.map { $0.rawValue }
@@ -40,4 +57,5 @@ enum MainMessages: String, CaseIterable {
         // 쉼표를 기준으로 줄바꿈 추가
         let formattedMessage = randomMessage.replacingOccurrences(of: ",", with: ",\n")
         return formattedMessage
-    }}
+    }
+}

--- a/Sodam/Sodam/Main/View/MainViewController.swift
+++ b/Sodam/Sodam/Main/View/MainViewController.swift
@@ -31,7 +31,7 @@ final class MainViewController: UIViewController {
     }
     
     /// 뷰가 다시 나타날 때 데이터 갱신
-    override func viewIsAppearing(_ animated: Bool) {
+    override func viewWillAppear (_ animated: Bool) {
         viewModel.reloadHanhdam() // ViewModel에서 행담이 데이터를 갱신
     }
     

--- a/Sodam/Sodam/Main/View/MainViewController.swift
+++ b/Sodam/Sodam/Main/View/MainViewController.swift
@@ -121,7 +121,7 @@ extension MainViewController: WriteViewControllerDelegate {
     func writeViewControllerDiddismiss() {
         print("WriteViewController 모달이 닫혔습니다.")
         
-        viewModel.updateMessage()
+//        viewModel.updateMessage()
         viewModel.setGif()
     }
 }

--- a/Sodam/Sodam/Main/View/MainViewController.swift
+++ b/Sodam/Sodam/Main/View/MainViewController.swift
@@ -8,12 +8,16 @@
 import UIKit
 import Combine
 
+/// MainView와 MainViewModel을 연결하여 화면을 제어하는 ViewController
 final class MainViewController: UIViewController {
     
-    //뷰, 뷰모델 연결
+    // MARK: - Properties
+    
     private let mainView: MainView  = MainView()
     private let viewModel: MainViewModel = MainViewModel()
     private var cancellables: Set<AnyCancellable> = Set<AnyCancellable>()
+    
+    // MARK: - Lifecycle Methods
     
     override func loadView() {
         self.view = mainView
@@ -21,51 +25,57 @@ final class MainViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        bindViewModel()
+        bindViewModel()            // viewModel과 view를 바인딩
         configureButtonAction()    // 작성 버튼 액션 설정
-        addGesture()               // 이미지 탭 제스처
+        addGesture()               // 이미지 탭 제스처 설정
+    }
+    
+    /// 뷰가 다시 나타날 때 데이터 갱신
+    override func viewIsAppearing(_ animated: Bool) {
+        viewModel.reloadHanhdam() // ViewModel에서 행담이 데이터를 갱신
     }
     
     // MARK: - bind view model for update view
     
+    /// ViewModel과 View를 바인딩 해서 데이터 변화를 UI에 반영함.
     private func bindViewModel() {
-        viewModel.$name
+        viewModel.$hangdam
             .receive(on: RunLoop.main)
-            .sink { [weak self] name in
-                self?.mainView.updateNameLabel(name ?? "알 수 없는 알") // TODO: 이름이 안 정해졌을 때 비워두는 것보다 귀여운 이름 넣으면 좋을 거 같아요
+            .sink { [weak self] hangdam in
+                self?.mainView.updateNameLabel(hangdam.name ?? "이름을 지어주세요") // 이름 설정
+                self?.mainView.updateGif(with: "phase\(hangdam.level)") // 레벨에 따른 GIF 업데이트
             }
             .store(in: &cancellables)
         
+        // 메세지 데이터 변경 시 UI 업데이트
         viewModel.$message
             .receive(on: RunLoop.main)
             .sink { [weak self] message in
                 self?.mainView.updateMessage(message)
             }
             .store(in: &cancellables)
-        
-        viewModel.$gifName
-            .receive(on: RunLoop.main)
-            .sink { [weak self] gifName in
-                self?.mainView.updateGif(with: gifName)
-            }
-            .store(in: &cancellables)
     }
     
     // MARK: - setup button action
     
-    // 작성 버튼 클릭 시 액션 설정
+    /// 작성 버튼 클릭 시 액션 설정
     private func configureButtonAction() {
         mainView.createbutton.addTarget(self, action: #selector(createButtonTapped), for: .touchUpInside)
     }
     
-    // 이미지 뷰 탭할 때 액션 설정
+    /// 이미지 뷰 탭할 때 액션 설정
     private func addGesture() {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(imageViewTap))
         mainView.circularImageView.addGestureRecognizer(tapGesture)
         mainView.circularImageView.isUserInteractionEnabled = true
     }
     
+    // MARK: - Lazy Properties
+    
+    /// 작성 화면을 위한 ViewModel 생성. (행담이 ID와 함께 초기화)
     private lazy var writeViewModel: WriteViewModel = .init(writeModel: WriteModel(), hangdamID: viewModel.getCurrentHangdamID())
+    
+    // MARK: - Modal Handling
     
     // 작성화면 모달 띄우는 메서드
     private func modalWriteViewController(with name: String) {
@@ -76,9 +86,11 @@ final class MainViewController: UIViewController {
         present(writeViewController, animated: true)                            // 모달 표시
     }
     
-    // 작성 버튼 클릭 시 호출
+    // MARK: - Button Actions
+    
+    /// 작성 버튼 클릭 시 호출
     @objc private func createButtonTapped() {
-        if let name = viewModel.name {
+        if let name = viewModel.hangdam.name {
             // 이미 저장된 이름이 있는 경우에 바로 작성화면으로 이동
             print("저장된 이름으로 작성화면 이동함: \(name)")
             modalWriteViewController(with: name)
@@ -92,14 +104,16 @@ final class MainViewController: UIViewController {
                     print("이름이 입력되지 않았습니다.")
                     return
                 }
-                viewModel.saveNewName(as: name)
+                viewModel.saveNewName(as: name) // 새 이름 저장
                 print("입력 된 이름: \(name)")
                 self.modalWriteViewController(with: name) // 작성 화면으로 이동
             }
         }
     }
     
-    // 이미지 탭 액션
+    // MARK: - Gesture Actions
+    
+    /// 이미지 탭 액션
     @objc private func imageViewTap() {
         // 연속 클릭 방지
         mainView.circularImageView.isUserInteractionEnabled = false             // 클릭 비활성화
@@ -107,7 +121,7 @@ final class MainViewController: UIViewController {
         // 저정된 이름 유무에 따라서 메세지 업데이트
         viewModel.updateMessage()
         
-        // 2초 후 다시 활성화
+        // 1초 후 다시 활성화
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
             self.mainView.circularImageView.isUserInteractionEnabled = true     // 클릭 재활성화
         }
@@ -116,18 +130,17 @@ final class MainViewController: UIViewController {
 
 // MARK: - extension for delegate
 
-// 작성화면 모달이 닫힐 때 처리
+/// 작성화면 모달이 닫힐 때 처리.
 extension MainViewController: WriteViewControllerDelegate {
     func writeViewControllerDiddismiss() {
         print("WriteViewController 모달이 닫혔습니다.")
-        
-//        viewModel.updateMessage()
-        viewModel.setGif()
+        viewModel.reloadHanhdam() // 데이터 갱신
     }
 }
-
+/// 텍스트 입력 제한을 위해 UITextFieldDelegate 구현.
 extension MainViewController: UITextFieldDelegate {
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        
         // 현재 텍스트와 새로운 텍스트를 합친 길이가 6글자를 초과하지 않도록 제한
         let currentText = textField.text ?? ""
         let newText = (currentText as NSString).replacingCharacters(in: range, with: string)

--- a/Sodam/Sodam/Main/View/MainViewModel.swift
+++ b/Sodam/Sodam/Main/View/MainViewModel.swift
@@ -8,37 +8,32 @@
 import Foundation
 import Combine
 
+/// MainView의 상태와 로직을 관리하는 ViewModel.
+/// HangdamRepository와 상호작용해서 데이터를 관리하고 Published 속성을 통해서 UI를 업데이트 함.
 final class MainViewModel: ObservableObject {
-    @Published var name: String?
-    @Published var message: String = "" // 화면 메시지
-    @Published var gifName: String = "phase0" // gif name
+    @Published var hangdam: HangdamDTO // 현재 관리할 행담이 데이터
+    @Published var message: String = "" // 화면에 표시할 메시지
     
+    // 행담이 데이터 저장 및 불러오는 레포지토리
     private let hangdamRepository: HangdamRepository
     
+    /// 뷰모델 초기화 메서드
     init(repository: HangdamRepository = HangdamRepository()) {
         self.hangdamRepository = repository
-        self.name = hangdamRepository.getCurrentHangdam().name
+        self.hangdam = repository.getCurrentHangdam() // 현재 행담이 데이터를 레포지토리에서 가져옴
         self.updateMessage() // 초기화 시 메세지 업데이트
         
         // 행담이 레벨업 할때마다 특정 메시지를 보여주기 위해 observing
         NotificationCenter.default.addObserver(self, selector: #selector(updateMessageWhenLevelUp), name: Notification.levelUP, object: nil)
     }
-    
-    func setGif() {
-        self.name = hangdamRepository.getCurrentHangdam().name
-        if name != nil {
-            gifName = "phase\(hangdamRepository.getCurrentHangdam().level)"
-        } // TODO: 이름이 없는 경우 레벨이 0으로 고정이라면 if let 자체가 필요없을 듯
-    }
-    
+    /// 새로운 이름을 현재 행담이에 저장
     func saveNewName(as name: String ) {
-        let currentHangdamID: String = hangdamRepository.getCurrentHangdam().id
-        hangdamRepository.nameHangdam(id: currentHangdamID, name: name)
-        setGif()
+        hangdamRepository.nameHangdam(id: hangdam.id, name: name)
+        
     }
-    
+    /// 행담이 이름 유무에 따라 화면 메세지를 업데이트 함
     func updateMessage() {
-        if let _ = name {
+        if let _ = hangdam.name {
             message = MainMessages.getRandomMessage()
             print("이름이 지어졌음. 랜덤 메시지 표시")
         } else {
@@ -47,20 +42,28 @@ final class MainViewModel: ObservableObject {
         }
     }
     
+    /// 레포지토리에서 현재 행담이 데이터를 다시 불러옴
+    func reloadHanhdam() {
+        self.hangdam = hangdamRepository.getCurrentHangdam()
+    }
+    
+    /// 현재 행담이의 ID를 반환함
     func getCurrentHangdamID() -> String {
         return hangdamRepository.getCurrentHangdam().id
     }
     
+    /// 행담이가 레벨업 할 때 메세지를 업데이트 함
+    /// `levelUP` 알림(Notification)을 통해 호출됨
     @objc func updateMessageWhenLevelUp(notification: Notification) {
         guard let userInfo = notification.userInfo,
               let level = userInfo["level"] as? Int
         else { return }
         
-        /// 디버깅
+        // 디버깅
         print("행담이 레벨 \(level)로 성장함")
         
-        message = MainMessages.messageForLevel(level, name: name ?? "")
-        gifName = "phase\(level)"
+        // 레벨에 따른 메세지를 업데이트
+        message = MainMessages.messageForLevel(level, name: hangdam.name ?? "")
     }
     
     /// deinit 시 observing 해제

--- a/Sodam/Sodam/Main/View/MainViewModel.swift
+++ b/Sodam/Sodam/Main/View/MainViewModel.swift
@@ -59,8 +59,8 @@ final class MainViewModel: ObservableObject {
         /// 디버깅
         print("행담이 레벨 \(level)로 성장함")
         
-        // TODO: 레벨에 따라 다른 메시지 설정
-        // MARK: 레벨에 따라 gif 설정하는 것도 여기서 하면 좋을 듯 (setGif 구현 여기로 옮기기)
+        message = MainMessages.messageForLevel(level, name: name ?? "")
+        gifName = "phase\(level)"
     }
     
     /// deinit 시 observing 해제

--- a/Sodam/Sodam/Main/View/MainViewModel.swift
+++ b/Sodam/Sodam/Main/View/MainViewModel.swift
@@ -26,11 +26,13 @@ final class MainViewModel: ObservableObject {
         // 행담이 레벨업 할때마다 특정 메시지를 보여주기 위해 observing
         NotificationCenter.default.addObserver(self, selector: #selector(updateMessageWhenLevelUp), name: Notification.levelUP, object: nil)
     }
+    
     /// 새로운 이름을 현재 행담이에 저장
     func saveNewName(as name: String ) {
         hangdamRepository.nameHangdam(id: hangdam.id, name: name)
-        
+        reloadHanhdam()
     }
+    
     /// 행담이 이름 유무에 따라 화면 메세지를 업데이트 함
     func updateMessage() {
         if let _ = hangdam.name {


### PR DESCRIPTION
## 1. 요약 
- MainViewModel에서 DTO 관리
- HangdamRepository를 통해 HangdamDTO 데이터를 가져오고, 이를 @Published 속성으로 관리.
- HangdamDTO의 데이터 변경이 일어나면 Combine을 통해 알림을 전달.
- MainViewController에서 viewModel.$hangdam과 viewModel.$message를 구독.
- 데이터가 변경되면 UI를 업데이트하는 코드(updateNameLabel, updateGif, updateMessage)를 호출해서 즉시 반영하게 함

- 앱이 재실행 될때 알 상태인 GIF 가 나왔던 것 해결

## 2. 스크린샷

![화면 기록 2025-01-28 오후 2 05 18](https://github.com/user-attachments/assets/7742b120-2324-4f2c-bcef-b488c5c8b0be)

## 3. 공유사항

데이터의 구조와 변환 로직이 DTO 내부로 캡슐화되어서 더이상 ViewModel과 ViewController가 데이터 변환을 걱정하지 않아도 되게 했습니다!

- 알을깨고 나왔을 때 이름이 표시 되지 않아서 이름 저장 후 데이터를 다시 로드하는 코드를 추가작성하여 정상출력 되는것 확인했습니다
![화면 기록 2025-01-28 오후 3 03 15](https://github.com/user-attachments/assets/17364953-2a90-4584-b81d-79b4d47cd9c3)


