### PR TITLE
[Fix] 알림 울리면서 뱃지 +1 증가, 앱 진입시 뱃지 초기화 수정

### DIFF
--- a/Sodam/Sodam/Delegate/AppDelegate.swift
+++ b/Sodam/Sodam/Delegate/AppDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import UserNotifications
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -54,12 +55,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 // MARK: - UNUserNotificationCenterDelegate Setting Method
 
 extension AppDelegate: UNUserNotificationCenterDelegate {
-    // foreground 상태인 경우(앱 실행중인상태) 알림이 오면 해당 메서드 호출
+    // Foreground 상태인 경우(앱 실행중인상태) 알림이 오면 해당 메서드 호출
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        print("🔔 Foreground에서 알림 수신: \(notification.request.identifier)") // 로그 추가
+        // 알림 수신 시 뱃지 수를 1씩 증가
+        let currentBadgeCount = UIApplication.shared.applicationIconBadgeNumber
+        UIApplication.shared.applicationIconBadgeNumber = currentBadgeCount + 1
+        
         completionHandler([.banner, .badge, .sound, .list])
     }
     
-    // 사용자가 알림을 탭했을때 해당 메서드 호출
+    // Background에서 알림 클릭 시 처리사용자가 알림을 탭했을때 해당 메서드 호출
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
         completionHandler()  // 응답 처리가 완료되었음을 시스템에 알림
     }

--- a/Sodam/Sodam/Delegate/SceneDelegate.swift
+++ b/Sodam/Sodam/Delegate/SceneDelegate.swift
@@ -52,7 +52,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             overlayView.removeFromSuperview() // 오버레이 제거
         })
     }
+    
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        print("✅ 앱이 활성화됨 - 뱃지 초기화")
+        UIApplication.shared.applicationIconBadgeNumber = 0
+    }
 }
-
-
-

--- a/Sodam/Sodam/Main/View/MainViewModel.swift
+++ b/Sodam/Sodam/Main/View/MainViewModel.swift
@@ -30,7 +30,7 @@ final class MainViewModel: ObservableObject {
     
     /// 새로운 이름을 현재 행담이에 저장
     func saveNewName(as name: String ) {
-        hangdamRepository.nameHangdam(id: hangdam.id, name: ngitame)
+        hangdamRepository.nameHangdam(id: hangdam.id, name: name)
         reloadHanhdam()
     }
     

--- a/Sodam/Sodam/Manager/LocalNotificationManager.swift
+++ b/Sodam/Sodam/Manager/LocalNotificationManager.swift
@@ -5,46 +5,37 @@
 //  Created by 박시연 on 1/22/25.
 //
 
-import Foundation
 import UserNotifications
+import UIKit
 
 final class LocalNotificationManager {
     static let shared = LocalNotificationManager()
     
     private init() {}
     
-    /// 특정 시점에 알람 설정(사용자가 선택한 날짜)
+    /// 특정 시점에 알람 설정(매일, 사용자가 선택한 시간)
     /// - Parameters:
-    ///   - title: Push Notification에 표시할 제목
-    ///   - body: Push Notification에 표시할 본문
     ///   - time: 사용자가 설정한 알림 시간
-    ///   - seconds: 현재로부터 seconds초 이후에 알림을 보냅니다. 0보다 커야하며 1이하 실수도 가능
-    ///   - identifier: 실행 취소, 알림 구분 등에 사용되는 식별자입니다. "TEST_NOTI" 형식으로 작성
-    func pushReservedNotification(title: String,
-                                  body: String,
-                                  time: Date,
-                                  seconds: Double,
-                                  identifier: String) {
+    func setReservedNotification(_ time: Date) {
+        let content = UNMutableNotificationContent()
+        content.title = "Sodam"  // Push Notification에 표시할 제목
+        content.body = "소소한 행복을 적어 행담이를 키워주세요."  // Push Notification에 표시할 본문
+        content.sound = .default
+        content.badge = NSNumber(value: UIApplication.shared.applicationIconBadgeNumber + 1) // 기존 뱃지 숫자에서 1씩 증가
         
-        // 알림 내용, 설정
-        let notificationContent = UNMutableNotificationContent()
-        notificationContent.title = title
-        notificationContent.body = body
+        let calendar = Calendar.current
+        let components = calendar.dateComponents([.hour, .minute], from: time)
         
-        // 알림이 발송될 정확한 시간 설정
-        let triggerComponents = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second], from: time)
-        // 사용자가 지정한 `time`을 기반으로 알림 트리거를 설정
-        let trigger = UNCalendarNotificationTrigger(dateMatching: triggerComponents, repeats: true)
+        let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: true) // ✅ 매일 설정한 시간에 울리게 설정
+        
+        // identifier: 실행 취소, 알림 구분 등에 사용되는 식별자
+        let request = UNNotificationRequest(identifier: "SelectedTimeNotification", content: content, trigger: trigger)
 
-        // 알림 요청 생성
-        let request = UNNotificationRequest(identifier: identifier,
-                                            content: notificationContent,
-                                            trigger: trigger)
-        
-        // 알림 등록
         UNUserNotificationCenter.current().add(request) { error in
             if let error = error {
-                print("Notification Error: ", error)
+                print("❌ 알림 등록 실패: \(error.localizedDescription)")
+            } else {
+                print("✅ 알림 등록 성공! 예약 시간: \(components.hour ?? 0):\(components.minute ?? 0)")
             }
         }
     }

--- a/Sodam/Sodam/Setting/SettingViewModel/SettingViewModel.swift
+++ b/Sodam/Sodam/Setting/SettingViewModel/SettingViewModel.swift
@@ -46,12 +46,7 @@ final class SettingViewModel {
     }
         
     func setReservedNotificaion(_ sender: Date) {
-        localNotificationManager.pushReservedNotification(
-            title: "Sodam",
-            body: "소소한 행복을 적어 행담이를 키워주세요.",
-            time: sender,
-            seconds: 0,
-            identifier: "SelectedTimeNotification")
+        localNotificationManager.setReservedNotification(sender)
     }
     
     // URL 열기 메서드

--- a/Sodam/Sodam/Setting/SettingsViewController.swift
+++ b/Sodam/Sodam/Setting/SettingsViewController.swift
@@ -31,6 +31,12 @@ final class SettingsViewController: UIViewController {
         setupTableView()
         setupScheduledNotification()
     }
+    
+    // 설정화면에 진입한 순간 뱃지 초기화 시키기 위함
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        UIApplication.shared.applicationIconBadgeNumber = 0
+    }
 }
 
 // MARK: - Private Method

--- a/Sodam/Sodam/Setting/SettingsViewController.swift
+++ b/Sodam/Sodam/Setting/SettingsViewController.swift
@@ -31,12 +31,6 @@ final class SettingsViewController: UIViewController {
         setupTableView()
         setupScheduledNotification()
     }
-    
-    // 설정화면에 진입한 순간 뱃지 초기화 시키기 위함
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        UIApplication.shared.applicationIconBadgeNumber = 0
-    }
 }
 
 // MARK: - Private Method


### PR DESCRIPTION
## 1. 요약 
알림이 울리고 알림 미확인 시 뱃지 +1씩 증가
알림이 울리고 바로 알림 확인 시 뱃지 숫자 초기화
알림이 울리고 뱃지 숫자가 쌓인 상태에서 설정 화면으로 진입 시 뱃지 숫자 초기화

## 2. 스크린샷 

![Simulator Screen Recording - iPhone 16 Pro - 2025-01-30 at 16 16 24](https://github.com/user-attachments/assets/0e9663c2-866f-4c27-aa98-2e369949499e)

## 3. 공유사항

설정화면으로 진입 했을때 뱃지가 초기화 되도록하였는데 해당 로직이 어색한지, 
탭바 설정아이콘에도 동일하게 뱃지 표시가 되면 좋을거같긴한것같습니다..(가능한지 잘 모르겠어요)
앱 진입시 초기화되는게 나은지 고민이 되는 부분입니다..!