### PR TITLE
[Feat] 행담이 상태 뷰, 보관함 뷰 데이터 바인딩

### DIFF
--- a/Sodam/Sodam/CoreData/DTO/HangdamDTO.swift
+++ b/Sodam/Sodam/CoreData/DTO/HangdamDTO.swift
@@ -24,6 +24,16 @@ struct HangdamDTO {
         default: return 0       // 알담이 : 1개 작성 필요
         }
     }
+    
+    var levelName: String {
+        switch level {
+        case 1: "애기 행담이"
+        case 2: "초딩 행담이"
+        case 3: "중딩 행담이"
+        case 4, 5: "킹담이"
+        default: "알 속 행담이"
+        }
+    }
 }
 
 extension HangdamEntity {

--- a/Sodam/Sodam/Extension/+Image.swift
+++ b/Sodam/Sodam/Extension/+Image.swift
@@ -1,0 +1,20 @@
+//
+//  +Image.swift
+//  Sodam
+//
+//  Created by EMILY on 31/01/2025.
+//
+
+import SwiftUI
+
+extension Image {
+    static func hangdamImage(level: Int) -> Image {
+        switch level {
+        case 1: .init(.level1)
+        case 2: .init(.level2)
+        case 3: .init(.level3)
+        case 4, 5: .init(.level4)
+        default: .init(.level0)
+        }
+    }
+}

--- a/Sodam/Sodam/HangdamStatusView.swift
+++ b/Sodam/Sodam/HangdamStatusView.swift
@@ -15,7 +15,8 @@ struct HangdamStatusView: View {
     
     var body: some View {
         HStack(alignment: .center, spacing: 20) {
-            Image(.level1)
+            Image
+                .hangdamImage(level: hangdam.level)
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(width: size.width / 3)

--- a/Sodam/Sodam/HangdamStatusView.swift
+++ b/Sodam/Sodam/HangdamStatusView.swift
@@ -25,9 +25,9 @@ struct HangdamStatusView: View {
             
             VStack(alignment: .leading, spacing: 10) {
                 Text(hangdam.name ?? "이름을 지어주세요!")
-                    .font(.maruburiot(type: .bold, size: 25))
-                Text("Lv.\(hangdam.level) 애기 행담이")
-                    .font(.maruburiot(type: .semiBold, size: 18))
+                    .font(.maruburiot(type: .bold, size: hangdam.name == nil ? 18 : 25))
+                Text("Lv.\(hangdam.level) \(hangdam.levelName)")
+                    .font(.maruburiot(type: .semiBold, size: 17))
                 if let startDate = hangdam.startDate {
                     Text("\(startDate) ~")
                         .font(.maruburiot(type: .regular, size: 16))

--- a/Sodam/Sodam/HangdamStorage/HangdamGridView.swift
+++ b/Sodam/Sodam/HangdamStorage/HangdamGridView.swift
@@ -44,7 +44,7 @@ fileprivate struct HangdamGrid: View {
                         .foregroundStyle(Color(uiColor: .darkGray))
                     if let startDate = hangdam.startDate, let endDate = hangdam.endDate {
                         Text("\(startDate) ~ \(endDate)")
-                            .font(.maruburiot(type: .regular, size: 14))
+                            .font(.maruburiot(type: .regular, size: 13))
                             .foregroundStyle(Color(uiColor: .gray))
                     } else {
                         Text("")

--- a/Sodam/Sodam/HangdamStorage/HangdamGridView.swift
+++ b/Sodam/Sodam/HangdamStorage/HangdamGridView.swift
@@ -42,8 +42,8 @@ fileprivate struct HangdamGrid: View {
                     Text(hangdam.name ?? "이름을 잃었다.")
                         .font(.maruburiot(type: .bold, size: 16))
                         .foregroundStyle(Color(uiColor: .darkGray))
-                    if let startDate = hangdam.startDate {
-                        Text(startDate)
+                    if let startDate = hangdam.startDate, let endDate = hangdam.endDate {
+                        Text("\(startDate) ~ \(endDate)")
                             .font(.maruburiot(type: .regular, size: 14))
                             .foregroundStyle(Color(uiColor: .gray))
                     } else {

--- a/Sodam/Sodam/HangdamStorage/HangdamStorageView.swift
+++ b/Sodam/Sodam/HangdamStorage/HangdamStorageView.swift
@@ -22,11 +22,20 @@ struct HangdamStorageView: View {
                             .clipShape(.rect(cornerRadius: 15))
                     }
                     
-                    Text("행담이 보관함")
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .font(.mapoGoldenPier(27))
-                        .foregroundStyle(Color.textAccent)
-                        .padding(.top)
+                    HStack(alignment: .bottom) {
+                        Text("행담이 보관함")
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .font(.mapoGoldenPier(27))
+                            .foregroundStyle(Color.textAccent)
+                            .padding(.top)
+                        
+                        Text("다 자란 행담이 : \($viewModel.storedHangdamList.wrappedValue.count)")
+                            .font(.mapoGoldenPier(15))
+                            .foregroundStyle(Color.white)
+                            .padding(.vertical, 7)
+                            .padding(.horizontal, 12)
+                            .background(Capsule().fill(Color.buttonBackground))
+                    }
                     
                     ScrollView {
                         HangdamGridView(hangdamList: $viewModel.storedHangdamList)


### PR DESCRIPTION
## 1. 요약
- 행담이 상태 : 레벨 별 행담이 이미지와 레벨 별 행담이 명칭 적용
- 행담이 보관함 : 행담이 기억 저장한 기간 바인딩
- 다 자란 행담이 수 뷰 추가
## 2. 스크린샷
<img width="424" alt="Screenshot 2025-01-31 at 12 05 20" src="https://github.com/user-attachments/assets/44354951-c210-4e0a-83ec-fa914ae033f8" />
<img width="422" alt="Screenshot 2025-01-31 at 12 05 39" src="https://github.com/user-attachments/assets/a205092e-d1c8-48ec-88ee-9f0e2578b4ad" />
<img width="422" alt="Screenshot 2025-01-31 at 12 05 57" src="https://github.com/user-attachments/assets/b7d5a148-3210-405d-956b-5af6b45ff015" />
<img width="421" alt="Screenshot 2025-01-31 at 12 06 13" src="https://github.com/user-attachments/assets/46282f61-608c-4199-ad46-3c75e60b3eab" />
<img width="422" alt="Screenshot 2025-01-31 at 12 06 24" src="https://github.com/user-attachments/assets/23fb0a9c-fe4a-4e35-8ed1-802447c3777a" />
<img width="422" alt="Screenshot 2025-01-31 at 12 08 16" src="https://github.com/user-attachments/assets/780f3ae0-88ff-4790-8e55-f8b080bdd70f" />

## 3. 공유사항
행담이 레벨 별 명칭의 경우 HangdamDTO에 계산 프로퍼티로 추가하였습니다.

## 4. 논의사항
1. 메인 뷰에 "점잖스러운" 표현 수정이 필요합니다. 또, "변신"보다 "성장"이라는 표현이 자연스러울 거 같다는 제안 드립니다.
<img width="410" alt="Screenshot 2025-01-31 at 12 09 11" src="https://github.com/user-attachments/assets/2a12b033-f86c-4751-b571-4a5723197989" />

2. "멍담이"라고 지었을 때 행복 리스트 뷰로 이동하면 "멍담이담이"라고 표시되기 때문에 사용자로 하여금 "담이" 앞에 붙을 명칭을 짓도록 확실하게 유도할 필요가 있습니다.
<img width="420" alt="Screenshot 2025-01-31 at 12 09 39" src="https://github.com/user-attachments/assets/27c71d4d-993c-45a6-9ed2-922496f52fbd" />

3. 논의하면 좋을 점
- 하루에 기억 하나만 기록하도록 조치 필요성
- 현재 성장 중인 행담이가 가진 기억은 삭제하지 못하도록 막는 것 필요성