### PR TITLE
[Feat] 1일 1작성 유저디폴츠 구현 및 몇 가지 수정

### DIFF
--- a/Sodam/Sodam.xcodeproj/project.pbxproj
+++ b/Sodam/Sodam.xcodeproj/project.pbxproj
@@ -152,9 +152,12 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 5PK5H7T5K9;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Sodam/Configuration/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -169,6 +172,8 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = gyeomsony.Sodam;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = sodam_development;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -184,9 +189,12 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 5PK5H7T5K9;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Sodam/Configuration/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -201,6 +209,8 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = gyeomsony.Sodam;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = sodam_development;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/Sodam/Sodam/Main/Utilities/AlertManager.swift
+++ b/Sodam/Sodam/Main/Utilities/AlertManager.swift
@@ -26,15 +26,26 @@ final class AlertManager {
     ) {
         let alartController = UIAlertController(
             title: "이름 짓기",
-            message: "이름을 6글자 이내로 적어주세요",
+            message: "4글자 이내로 지어주세요",
             preferredStyle: .alert
         )
         
         // 알럿 안에 텍스트 필드
-        alartController.addTextField { TextField in
-            TextField.placeholder = "행담이 이름을 적어주세요"
+        alartController.addTextField { textField in
+            textField.placeholder = "이름을 입력하세요"
             // 텍스트 필드 델리게이트
-            TextField.delegate = viewController as? UITextFieldDelegate
+            textField.delegate = viewController as? UITextFieldDelegate
+            
+            // 텍스트필드 옆에 Label추가
+            let rightLabel = UILabel()
+            rightLabel.text = "담이"
+            rightLabel.font = .mapoGoldenPier(14)
+            rightLabel.textColor = .gray
+            rightLabel.sizeToFit()
+            
+            // Label을 rightView로 설정
+            textField.rightView = rightLabel
+            textField.rightViewMode = .always
         }
         
         // 확인 버튼

--- a/Sodam/Sodam/Main/View/MainMessages.swift
+++ b/Sodam/Sodam/Main/View/MainMessages.swift
@@ -35,15 +35,15 @@ enum MainMessages: String, CaseIterable {
     static func messageForLevel(_ level: Int, name: String) -> String {
         switch level {
         case 1:
-            return "드디어 알을 깨고 아기 \(name)(이)가 눈을 마주치네요!"
+            return "드디어 알을 깨고 아기 \(name)담이가 눈을 마주치네요!"
         case 2:
-            return "하트 윙크 발사하는 사랑스러운 \(name)로 변신했네요!"
+            return "하트 윙크 발사하는 사랑스러운 \(name)담이로 변신했네요!"
         case 3:
-            return "점잖스러운 \(name)로 변신 완료!"
+            return "어른스러운 \(name)담이로 성장 완료!"
         case 4:
-            return "소확행을 좋아하는 \(name)에게 행복한 기억을 더 줘볼까요?"
+            return "소확행을 좋아하는 \(name)담이에게 행복한 기억을 더 줘볼까요?"
         case 5:
-            return "\(name)가 당신의 소확행을 배부르게 먹고 보관되었습니다. 다음엔 누가 나올까요?"
+            return "\(name)담이가 당신의 소확행을 배부르게 먹고 보관되었습니다. 다음엔 누가 나올까요?"
         default:
             return "행복의 새로운 단계를 향해 나아가고 있어요!"
         }

--- a/Sodam/Sodam/Main/View/MainView.swift
+++ b/Sodam/Sodam/Main/View/MainView.swift
@@ -113,10 +113,11 @@ final class MainView: UIView {
     // 이름 라벨 업데이트
     func updateNameLabel(_ name: String?) {
         if let name = name, !name.isEmpty {
-            nameLabel.text = name
+            nameLabel.text = "\(name)담이"
             nameLabel.isHidden = false
         } else {
-            nameLabel.isHidden = true
+            nameLabel.text = "이름을 지어주세요"
+            nameLabel.isHidden = false
         }
     }
     

--- a/Sodam/Sodam/Main/View/MainViewController.swift
+++ b/Sodam/Sodam/Main/View/MainViewController.swift
@@ -53,7 +53,7 @@ final class MainViewController: UIViewController {
         viewModel.$hangdam
             .receive(on: RunLoop.main)
             .sink { [weak self] hangdam in
-                self?.mainView.updateNameLabel(hangdam.name ?? "이름을 지어주세요") // 이름 설정
+                self?.mainView.updateNameLabel(hangdam.name) // 이름 설정
                 self?.mainView.updateGif(with: "phase\(hangdam.level)") // 레벨에 따른 GIF 업데이트
             }
             .store(in: &cancellables)
@@ -152,9 +152,9 @@ extension MainViewController: WriteViewControllerDelegate {
 extension MainViewController: UITextFieldDelegate {
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         
-        // 현재 텍스트와 새로운 텍스트를 합친 길이가 6글자를 초과하지 않도록 제한
+        // 현재 텍스트와 새로운 텍스트를 합친 길이가 4글자를 초과하지 않도록 제한
         let currentText = textField.text ?? ""
         let newText = (currentText as NSString).replacingCharacters(in: range, with: string)
-        return newText.count <= 6
+        return newText.count <= 4
     }
 }

--- a/Sodam/Sodam/Main/View/MainViewModel.swift
+++ b/Sodam/Sodam/Main/View/MainViewModel.swift
@@ -55,6 +55,18 @@ final class MainViewModel: ObservableObject {
         return hangdamRepository.getCurrentHangdam().id
     }
     
+    /// 오늘 작성했는지 확인하는 메서드
+    func hasAlreadyWrittenToday() -> Bool {
+        let lastWrittenDate = UserDefaults.standard.object(forKey: "lastWrittenDate") as? Date ?? Date.distantPast
+        let calendar = Calendar.current
+        return calendar.isDateInToday(lastWrittenDate)
+    }
+    
+    /// 오늘 작성했다고 UserDefaults에 lastWrittenDate라는 키로 저장
+    func markAsWrittenToday() {
+        UserDefaults.standard.set(Date(), forKey: "lastWrittenDate")
+    }
+    
     /// 행담이가 레벨업 할 때 메세지를 업데이트 함
     /// `levelUP` 알림(Notification)을 통해 호출됨
     @objc func updateMessageWhenLevelUp(notification: Notification) {


### PR DESCRIPTION
## 1. 요약
- 이름 4글자로 제한
- "~ 담이" 로 나올 수 있게 메인뷰에 모든 이름 부분 수정 
- 이름 지어줄 때도 텍스트필드 옆에 "담이" 글자 나오게 함 
- 오늘 날짜에 등록된 소확행 기록이 있으면 다음날에 작성가능하도록 유저디폴츠로 구현
- 작성 안료 후 작성하기 버튼 탭시 작성 완료 알럿창 구현

## 2. 스크린샷 

![화면 기록 2025-01-31 오후 2 29 24](https://github.com/user-attachments/assets/677977bd-2cba-4ebd-be35-531922753f58)

## 3. 공유사항

- 어색한 부분 있으면 말씀해주세요