### PR TITLE
[Feat] ~담이 이름으로 나올 수 있게 수정 및 1일1작성 구현

### DIFF
--- a/Sodam/Sodam/CoreData/CoreDataManager.swift
+++ b/Sodam/Sodam/CoreData/CoreDataManager.swift
@@ -78,7 +78,7 @@ final class CoreDataManager {
         
         switch updateCase {
         case .name(let name):
-            entity.name = name.hasSuffix("담이") ? name : "\(name)담이"
+            entity.name = name
         case .startDate(let date):
             entity.startDate = date
         case .endDate(let date):

--- a/Sodam/Sodam/CoreData/CoreDataManager.swift
+++ b/Sodam/Sodam/CoreData/CoreDataManager.swift
@@ -78,7 +78,7 @@ final class CoreDataManager {
         
         switch updateCase {
         case .name(let name):
-            entity.name = name
+            entity.name = name.hasSuffix("담이") ? name : "\(name)담이"
         case .startDate(let date):
             entity.startDate = date
         case .endDate(let date):

--- a/Sodam/Sodam/HappinessList/HappinessListView.swift
+++ b/Sodam/Sodam/HappinessList/HappinessListView.swift
@@ -28,7 +28,7 @@ struct HappinessListView: View {
                     
                     if let happinessList = $viewModel.happinessList.wrappedValue,
                        !happinessList.isEmpty {
-                        Text("\($viewModel.hangdam.wrappedValue.name ?? "이름없는 ")담이가 먹은 기억들")
+                        Text("\($viewModel.hangdam.wrappedValue.name ?? "이름없는 ")가 먹은 기억들")
                             .frame(maxWidth: .infinity, maxHeight: 35, alignment: .leading)
                             .font(.mapoGoldenPier(FontSize.title2))
                             .lineLimit(1)

--- a/Sodam/Sodam/Main/Utilities/AlertManager.swift
+++ b/Sodam/Sodam/Main/Utilities/AlertManager.swift
@@ -26,15 +26,26 @@ final class AlertManager {
     ) {
         let alartController = UIAlertController(
             title: "이름 짓기",
-            message: "이름을 6글자 이내로 적어주세요",
+            message: "4글자 이내로 적어주세요",
             preferredStyle: .alert
         )
         
         // 알럿 안에 텍스트 필드
-        alartController.addTextField { TextField in
-            TextField.placeholder = "행담이 이름을 적어주세요"
+        alartController.addTextField { textField in
+            textField.placeholder = "이름을 입력하세요"
             // 텍스트 필드 델리게이트
-            TextField.delegate = viewController as? UITextFieldDelegate
+            textField.delegate = viewController as? UITextFieldDelegate
+            
+            // 텍스트필드 옆에 Label추가
+            let rightLabel = UILabel()
+            rightLabel.text = "담이"
+            rightLabel.font = .mapoGoldenPier(14)
+            rightLabel.textColor = .gray
+            rightLabel.sizeToFit()
+            
+            // Label을 rightView로 설정
+            textField.rightView = rightLabel
+            textField.rightViewMode = .always
         }
         
         // 확인 버튼

--- a/Sodam/Sodam/Main/Utilities/AlertManager.swift
+++ b/Sodam/Sodam/Main/Utilities/AlertManager.swift
@@ -24,19 +24,17 @@ final class AlertManager {
         on viewController: UIViewController,
         completion: @escaping (String?) -> Void
     ) {
-        let alartController = UIAlertController(
+        let alertController = UIAlertController(
             title: "이름 짓기",
             message: "4글자 이내로 적어주세요",
             preferredStyle: .alert
         )
         
-        // 알럿 안에 텍스트 필드
-        alartController.addTextField { textField in
+        alertController.addTextField { textField in
             textField.placeholder = "이름을 입력하세요"
-            // 텍스트 필드 델리게이트
-            textField.delegate = viewController as? UITextFieldDelegate
+            textField.addTarget(self, action: #selector(textFieldDidChange(_:)), for: .editingChanged) // 실시간 감지
             
-            // 텍스트필드 옆에 Label추가
+            // 텍스트필드 옆에 Label 추가
             let rightLabel = UILabel()
             rightLabel.text = "담이"
             rightLabel.font = .mapoGoldenPier(14)
@@ -48,9 +46,8 @@ final class AlertManager {
             textField.rightViewMode = .always
         }
         
-        // 확인 버튼
         let confirmAction = UIAlertAction(title: "확인", style: .default) { _ in
-            guard let name = alartController.textFields?.first?.text else {
+            guard let name = alertController.textFields?.first?.text, !name.isEmpty else {
                 viewController.view.showToast(message: "이름을 입력해주세요.")
                 return
             }
@@ -61,24 +58,40 @@ final class AlertManager {
                 return
             }
             
-            // 금지어 확인
             if containsForbiddenWord(name) {
                 viewController.view.showToast(message: "적절하지 않은 이름입니다.")
                 return
             }
-            completion(name) // 입력된 이름 전달
+            
+            let finalName = "\(name)담이" // 입력값 + "담이"
+            completion(finalName)
         }
-        confirmAction.setValue(UIColor.buttonBackground, forKey: "titleTextColor")
         
-        // 취소 버튼
         let cancelAction = UIAlertAction(title: "취소", style: .cancel)
-        cancelAction.setValue(UIColor.lightGray, forKey: "titleTextColor")
+
+        alertController.addAction(confirmAction)
+        alertController.addAction(cancelAction)
         
-        // 버튼 추가
-        alartController.addAction(confirmAction)
-        alartController.addAction(cancelAction)
-        
-        // 알림창 표시
-        viewController.present(alartController, animated: true)
+        viewController.present(alertController, animated: true)
+    }
+    
+    // 실시간 입력 감지
+    @objc private static func textFieldDidChange(_ textField: UITextField) {
+        DispatchQueue.main.async {
+            guard let text = textField.text else { return }
+            
+            if let lang = textField.textInputMode?.primaryLanguage, lang.hasPrefix("ko") {
+                // 한글 조합 중에도 4글자로 제한
+                if text.count > 4 {
+                    textField.text = String(text.prefix(4))
+                }
+            } else {
+                // 영어나 숫자 입력 시 8글자 초과 제한
+                if text.count > 8 {
+                    textField.text = String(text.prefix(8))
+                }
+            }
+        }
     }
 }
+

--- a/Sodam/Sodam/Main/Utilities/AlertManager.swift
+++ b/Sodam/Sodam/Main/Utilities/AlertManager.swift
@@ -56,8 +56,8 @@ final class AlertManager {
             }
             
             // 글자 수 확인
-            if name.count > 6 {
-                viewController.view.showToast(message: "이름은 6글자가 초과되었습니다.")
+            if name.count > 4 {
+                viewController.view.showToast(message: "최대 글자수를 초과했습니다.")
                 return
             }
             

--- a/Sodam/Sodam/Main/View/MainMessages.swift
+++ b/Sodam/Sodam/Main/View/MainMessages.swift
@@ -35,15 +35,15 @@ enum MainMessages: String, CaseIterable {
     static func messageForLevel(_ level: Int, name: String) -> String {
         switch level {
         case 1:
-            return "드디어 알을 깨고 아기 \(name)담이가 눈을 마주치네요!"
+            return "드디어 알을 깨고 아기 \(name)가 눈을 마주치네요!"
         case 2:
-            return "하트 윙크 발사하는 사랑스러운 \(name)담이로 성장했네요!"
+            return "하트 윙크 발사하는 사랑스러운 \(name)로 성장했네요!"
         case 3:
-            return "어른스러운 \(name)담이로 성장 완료!"
+            return "어른스러운 \(name)로 성장 완료!"
         case 4:
-            return "소확행을 좋아하는 \(name)담이에게 행복한 기억을 더 줘볼까요?"
+            return "소확행을 좋아하는 \(name)에게 행복한 기억을 더 줘볼까요?"
         case 5:
-            return "\(name)담이가 당신의 소확행을 배부르게 먹고 보관되었습니다. 다음엔 누가 나올까요?"
+            return "\(name)가 당신의 소확행을 배부르게 먹고 보관되었습니다. 다음엔 누가 나올까요?"
         default:
             return "행복의 새로운 단계를 향해 나아가고 있어요!"
         }

--- a/Sodam/Sodam/Main/View/MainMessages.swift
+++ b/Sodam/Sodam/Main/View/MainMessages.swift
@@ -37,7 +37,7 @@ enum MainMessages: String, CaseIterable {
         case 1:
             return "드디어 알을 깨고 아기 \(name)담이가 눈을 마주치네요!"
         case 2:
-            return "하트 윙크 발사하는 사랑스러운 \(name)담이로 변신했네요!"
+            return "하트 윙크 발사하는 사랑스러운 \(name)담이로 성장했네요!"
         case 3:
             return "어른스러운 \(name)담이로 성장 완료!"
         case 4:

--- a/Sodam/Sodam/Main/View/MainMessages.swift
+++ b/Sodam/Sodam/Main/View/MainMessages.swift
@@ -35,15 +35,15 @@ enum MainMessages: String, CaseIterable {
     static func messageForLevel(_ level: Int, name: String) -> String {
         switch level {
         case 1:
-            return "드디어 알을 깨고 아기 \(name)(이)가 눈을 마주치네요!"
+            return "드디어 알을 깨고 아기 \(name)담이가 눈을 마주치네요!"
         case 2:
-            return "하트 윙크 발사하는 사랑스러운 \(name)로 변신했네요!"
+            return "하트 윙크 발사하는 사랑스러운 \(name)담이로 변신했네요!"
         case 3:
-            return "점잖스러운 \(name)로 변신 완료!"
+            return "어른스러운 \(name)담이로 성장 완료!"
         case 4:
-            return "소확행을 좋아하는 \(name)에게 행복한 기억을 더 줘볼까요?"
+            return "소확행을 좋아하는 \(name)담이에게 행복한 기억을 더 줘볼까요?"
         case 5:
-            return "\(name)가 당신의 소확행을 배부르게 먹고 보관되었습니다. 다음엔 누가 나올까요?"
+            return "\(name)담이가 당신의 소확행을 배부르게 먹고 보관되었습니다. 다음엔 누가 나올까요?"
         default:
             return "행복의 새로운 단계를 향해 나아가고 있어요!"
         }

--- a/Sodam/Sodam/Main/View/MainView.swift
+++ b/Sodam/Sodam/Main/View/MainView.swift
@@ -93,7 +93,7 @@ final class MainView: UIView {
         }
         
         createbutton.snp.makeConstraints {
-            $0.bottom.equalTo(safeAreaLayoutGuide.snp.bottom).inset(50)
+            $0.bottom.equalTo(safeAreaLayoutGuide.snp.bottom).inset(40) // se에서 글자 겹쳐서 탭바사이 간격 좀 줄임
             $0.centerX.equalToSuperview()
             $0.height.equalTo(60)
             $0.width.equalToSuperview().multipliedBy(0.85)
@@ -114,9 +114,12 @@ final class MainView: UIView {
     func updateNameLabel(_ name: String?) {
         if let name = name, !name.isEmpty {
             nameLabel.text = name
+            nameLabel.text = "\(name)담이"
             nameLabel.isHidden = false
         } else {
             nameLabel.isHidden = true
+            nameLabel.text = "이름을 지어주세요"
+            nameLabel.isHidden = false
         }
     }
     

--- a/Sodam/Sodam/Main/View/MainView.swift
+++ b/Sodam/Sodam/Main/View/MainView.swift
@@ -114,7 +114,6 @@ final class MainView: UIView {
     func updateNameLabel(_ name: String?) {
         if let name = name, !name.isEmpty {
             nameLabel.text = name
-            nameLabel.text = "\(name)담이"
             nameLabel.isHidden = false
         } else {
             nameLabel.isHidden = true

--- a/Sodam/Sodam/Main/View/MainViewController.swift
+++ b/Sodam/Sodam/Main/View/MainViewController.swift
@@ -17,7 +17,6 @@ final class MainViewController: UIViewController {
     private let viewModel: MainViewModel
     private var cancellables: Set<AnyCancellable> = Set<AnyCancellable>()
     
-
     init(viewModel: MainViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
@@ -27,7 +26,7 @@ final class MainViewController: UIViewController {
         self.viewModel = MainViewModel(repository: HangdamRepository())
         super.init(nibName: nil, bundle: nil)
     }
-
+    
     // MARK: - Lifecycle Methods
     
     override func loadView() {
@@ -44,6 +43,7 @@ final class MainViewController: UIViewController {
     /// 뷰가 다시 나타날 때 데이터 갱신
     override func viewWillAppear (_ animated: Bool) {
         viewModel.reloadHanhdam() // ViewModel에서 행담이 데이터를 갱신
+//        updateButtonState()
     }
     
     // MARK: - bind view model for update view
@@ -53,7 +53,7 @@ final class MainViewController: UIViewController {
         viewModel.$hangdam
             .receive(on: RunLoop.main)
             .sink { [weak self] hangdam in
-                self?.mainView.updateNameLabel(hangdam.name ?? "이름을 지어주세요") // 이름 설정
+                self?.mainView.updateNameLabel(hangdam.name) // 이름 설정
                 self?.mainView.updateGif(with: "phase\(hangdam.level)") // 레벨에 따른 GIF 업데이트
             }
             .store(in: &cancellables)
@@ -66,6 +66,13 @@ final class MainViewController: UIViewController {
             }
             .store(in: &cancellables)
     }
+    
+    // 버튼 상태 갱신 메서드 추가
+//    private func updateButtonState() {
+//        let hasWritten = viewModel.hasAlreadyWrittenToday()
+//        mainView.createbutton.isEnabled = true // hasWritten이 true면 버튼 비활성화
+//        mainView.createbutton.alpha = hasWritten ? 0.5 : 1.0
+//    }
     
     // MARK: - setup button action
     
@@ -101,10 +108,20 @@ final class MainViewController: UIViewController {
     
     /// 작성 버튼 클릭 시 호출
     @objc private func createButtonTapped() {
+//        if viewModel.hasAlreadyWrittenToday() {
+//            // 오늘 작성한 경우 경고 메시지 출력
+//            let alert = UIAlertController(title: "오늘의 소확행 작성 완료!",
+//                                          message: "내일 또 당신의 소소한 행복을 작성해주세요",
+//                                          preferredStyle: .alert)
+//            alert.addAction(UIAlertAction(title: "확인", style: .default, handler: nil))
+//            present(alert, animated: true, completion: nil)
+//            return
+//        }
         if let name = viewModel.hangdam.name {
             // 이미 저장된 이름이 있는 경우에 바로 작성화면으로 이동
             print("저장된 이름으로 작성화면 이동함: \(name)")
             modalWriteViewController(with: name)
+            proceedWithWriting(name: name)
         } else {
             // 저장된 이름이 없는 경우 알림창 표시
             AlertManager.showAlert(on: self) { [weak self] name in
@@ -118,8 +135,16 @@ final class MainViewController: UIViewController {
                 viewModel.saveNewName(as: name) // 새 이름 저장
                 print("입력 된 이름: \(name)")
                 self.modalWriteViewController(with: name) // 작성 화면으로 이동
+                self.proceedWithWriting(name: name)
             }
         }
+    }
+    
+    /// 작성화면으로 이동 후 작성완료 상태를 저장하고 버튼 상태를 갱신하는 메서드
+    private func proceedWithWriting(name: String) {
+        modalWriteViewController(with: name)         // 작성화면으로 이동
+//        viewModel.markAsWrittenToday()               // 오늘 작성 했음을 기록
+//        updateButtonState()                          // 버튼 상태 갱신(작성 완료 시 비활성화됨)
     }
     
     // MARK: - Gesture Actions
@@ -152,9 +177,9 @@ extension MainViewController: WriteViewControllerDelegate {
 extension MainViewController: UITextFieldDelegate {
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         
-        // 현재 텍스트와 새로운 텍스트를 합친 길이가 6글자를 초과하지 않도록 제한
+        // 현재 텍스트와 새로운 텍스트를 합친 길이가 4글자를 초과하지 않도록 제한
         let currentText = textField.text ?? ""
         let newText = (currentText as NSString).replacingCharacters(in: range, with: string)
-        return newText.count <= 6
+        return newText.count <= 4
     }
 }

--- a/Sodam/Sodam/Main/View/MainViewModel.swift
+++ b/Sodam/Sodam/Main/View/MainViewModel.swift
@@ -55,6 +55,22 @@ final class MainViewModel: ObservableObject {
         return hangdamRepository.getCurrentHangdam().id
     }
     
+    // MARK: - TodayWriteUserDefaults(테스트 하는 동안 주석처리)
+    
+    /// 오늘 작성했는지 확인하는 메서드
+//    func hasAlreadyWrittenToday() -> Bool {
+//        let lastWrittenDate = UserDefaults.standard.object(forKey: "lastWrittenDate") as? Date ?? Date.distantPast
+//        let calendar = Calendar.current
+//        return calendar.isDateInToday(lastWrittenDate)
+//    }
+//    
+//    /// 오늘 작성했다고 UserDefaults에 lastWrittenDate라는 키로 저장
+//    func markAsWrittenToday() {
+//        let today = Calendar.current.startOfDay(for: Date())  // 시간을 00:00:00으로 초기화
+//        UserDefaults.standard.set(today, forKey: "lastWrittenDate")
+//        print("오늘 작성 기록 저장됨: \(today)")
+//    }
+    
     /// 행담이가 레벨업 할 때 메세지를 업데이트 함
     /// `levelUP` 알림(Notification)을 통해 호출됨
     @objc func updateMessageWhenLevelUp(notification: Notification) {


### PR DESCRIPTION
## 1. 요약
- 이름 4글자로 제한 (영어 8글자 - 넉넉하게 해도 크기가 크지 않아서)
- "~ 담이" 로 나올 수 있게 텍스트필드상에서 바로 저장하도록 구현
- 이름 지어줄 때도 텍스트필드 옆에 "담이" 글자 나오게 함 
- 오늘 날짜에 등록된 소확행 기록이 있으면 다음날에 작성가능하도록 유저디폴츠로 구현
- 작성 완료 후 작성하기 버튼 탭시 작성 완료 알럿창 구현

## 2. 스크린샷 

![화면 기록 2025-01-31 오후 2 29 24](https://github.com/user-attachments/assets/677977bd-2cba-4ebd-be35-531922753f58)


버튼 살짝 탭바랑 가깝게 거리 줄임, se3 테스트시 글이 3줄이 나올 때 버튼에 겹쳐서 보이지 않아서 수정함
<img width="416" alt="스크린샷 2025-01-31 오후 10 45 43" src="https://github.com/user-attachments/assets/097929d5-4a47-4ab4-b855-d1603b408266" />

## 3. 공유사항
- 이름 받침 있어도 가능한 부분 스크린샷 및 코어데이터 없이 텍스트필드상에서 저장되는 것 확인했습니다.
![화면 기록 2025-02-03 오전 11 22 15](https://github.com/user-attachments/assets/07da6db7-f995-4eff-97f3-8f319eb3a22f)


- 원활한 테스트를 위해서 유저디폴츠로 1일1작성 구현한 부분은 주석처리했습니다 바로 풀 받아도 영향가지 않게 테스트 3번 했습니다!
- 어색한 부분 있으면 말씀해주세요