### PR TITLE
[Fix] reload 버그와 endDate UI 버그 수정

### DIFF
--- a/Sodam/Sodam/CoreData/DTO/HangdamDTO.swift
+++ b/Sodam/Sodam/CoreData/DTO/HangdamDTO.swift
@@ -15,13 +15,17 @@ struct HangdamDTO {
     var endDate: String?
     
     var level: Int {
-        switch happinessCount {
-        case 1...3: return 1    // 애기담이 : 3개 작성 필요
-        case 4...10: return 2   // 초딩담이 : 7개 작성 필요
-        case 11...24: return 3  // 중딩담이 : 14개 작성 필요
-        case 25...29: return 4  // 킹담이 : 5개 작성해야 성장 완료
-        case 30: return 5       // 성장완료 보관 ㄱ
-        default: return 0       // 알담이 : 1개 작성 필요
+        if endDate != nil {
+            return 5
+        } else {
+            switch happinessCount {
+            case 1...3: return 1    // 애기담이 : 3개 작성 필요
+            case 4...10: return 2   // 초딩담이 : 7개 작성 필요
+            case 11...24: return 3  // 중딩담이 : 14개 작성 필요
+            case 25...29: return 4  // 킹담이 : 5개 작성해야 성장 완료
+            case 30: return 5       // 성장완료 보관 ㄱ
+            default: return 0       // 알담이 : 1개 작성 필요
+            }
         }
     }
     

--- a/Sodam/Sodam/HangdamStatusView.swift
+++ b/Sodam/Sodam/HangdamStatusView.swift
@@ -29,16 +29,17 @@ struct HangdamStatusView: View {
                 Text("Lv.\(hangdam.level) \(hangdam.levelName)")
                     .font(.maruburiot(type: .semiBold, size: 17))
                 if let startDate = hangdam.startDate {
-                    Text("\(startDate) ~")
+                    Text("\(startDate) ~ \(hangdam.endDate ?? "")")
                         .font(.maruburiot(type: .regular, size: 16))
+                        .minimumScaleFactor(0.7)
+                        .lineLimit(1)
                 } else {
                     Text("")
                 }
-                
             }
             .foregroundStyle(Color(uiColor: .white))
         }
-        .padding(16)
+        .padding(20)
         .frame(height: size.height / 4)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color.tabBackground)

--- a/Sodam/Sodam/HangdamStorage/HangdamGridView.swift
+++ b/Sodam/Sodam/HangdamStorage/HangdamGridView.swift
@@ -46,12 +46,14 @@ fileprivate struct HangdamGrid: View {
                         Text("\(startDate) ~ \(endDate)")
                             .font(.maruburiot(type: .regular, size: 13))
                             .foregroundStyle(Color(uiColor: .gray))
+                            .minimumScaleFactor(0.6)
+                            .lineLimit(1)
                     } else {
                         Text("")
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .padding([.leading, .bottom])
+                .padding([.horizontal, .bottom])
             }
             .background(Color.cellBackground)
             .clipShape(.rect(cornerRadius: 15))

--- a/Sodam/Sodam/HangdamStorage/HangdamGridView.swift
+++ b/Sodam/Sodam/HangdamStorage/HangdamGridView.swift
@@ -31,7 +31,7 @@ fileprivate struct HangdamGrid: View {
             HappinessListView(hangdam: hangdam)
         } label: {
             VStack(spacing: 1) {
-                Image(.kingdam1)
+                Image(.level4)
                     .resizable()
                     .aspectRatio(contentMode: .fit)
                     .background(Color.imageBackground)

--- a/Sodam/Sodam/Main/View/MainMessages.swift
+++ b/Sodam/Sodam/Main/View/MainMessages.swift
@@ -39,7 +39,7 @@ enum MainMessages: String, CaseIterable {
         case 2:
             return "하트 윙크 발사하는 사랑스러운 \(name)로 성장했네요!"
         case 3:
-            return "어른스러운 \(name)로 성장 완료!"
+            return "어엿한 \(name)로 성장 완료!"
         case 4:
             return "소확행을 좋아하는 \(name)에게 행복한 기억을 더 줘볼까요?"
         case 5:

--- a/Sodam/Sodam/Main/View/MainViewController.swift
+++ b/Sodam/Sodam/Main/View/MainViewController.swift
@@ -88,16 +88,11 @@ final class MainViewController: UIViewController {
         mainView.circularImageView.isUserInteractionEnabled = true
     }
     
-    // MARK: - Lazy Properties
-    
-    /// 작성 화면을 위한 ViewModel 생성. (행담이 ID와 함께 초기화)
-    private lazy var writeViewModel: WriteViewModel = .init(writeModel: WriteModel(), hangdamID: viewModel.hangdam.id)
-    
     // MARK: - Modal Handling
     
     // 작성화면 모달 띄우는 메서드
     private func modalWriteViewController(with name: String) {
-        let writeViewController = WriteViewController(writeViewModel: writeViewModel)
+        let writeViewController = WriteViewController(writeViewModel: .init(currentHangdamID: viewModel.hangdam.id))
         writeViewController.delegate = self                                     // Delegate 연결
         writeViewController.modalTransitionStyle = .coverVertical               // 모달 스타일 설정
         present(writeViewController, animated: true)                            // 모달 표시

--- a/Sodam/Sodam/Main/View/MainViewController.swift
+++ b/Sodam/Sodam/Main/View/MainViewController.swift
@@ -91,7 +91,7 @@ final class MainViewController: UIViewController {
     // MARK: - Lazy Properties
     
     /// 작성 화면을 위한 ViewModel 생성. (행담이 ID와 함께 초기화)
-    private lazy var writeViewModel: WriteViewModel = .init(writeModel: WriteModel(), hangdamID: viewModel.getCurrentHangdamID())
+    private lazy var writeViewModel: WriteViewModel = .init(writeModel: WriteModel(), hangdamID: viewModel.hangdam.id)
     
     // MARK: - Modal Handling
     

--- a/Sodam/Sodam/Main/View/MainViewController.swift
+++ b/Sodam/Sodam/Main/View/MainViewController.swift
@@ -162,7 +162,8 @@ final class MainViewController: UIViewController {
 extension MainViewController: WriteViewControllerDelegate {
     func writeViewControllerDiddismiss() {
         print("WriteViewController 모달이 닫혔습니다.")
-        viewModel.reloadHangdam() // 데이터 갱신
+        viewModel.reloadHangdam()   // 데이터 갱신
+        viewModel.updateMessage()   // 메시지 업데이트
     }
 }
 /// 텍스트 입력 제한을 위해 UITextFieldDelegate 구현.

--- a/Sodam/Sodam/Main/View/MainViewController.swift
+++ b/Sodam/Sodam/Main/View/MainViewController.swift
@@ -42,7 +42,7 @@ final class MainViewController: UIViewController {
     
     /// 뷰가 다시 나타날 때 데이터 갱신
     override func viewWillAppear (_ animated: Bool) {
-        viewModel.reloadHanhdam() // ViewModel에서 행담이 데이터를 갱신
+        viewModel.reloadHangdam() // ViewModel에서 행담이 데이터를 갱신
 //        updateButtonState()
     }
     
@@ -170,7 +170,7 @@ final class MainViewController: UIViewController {
 extension MainViewController: WriteViewControllerDelegate {
     func writeViewControllerDiddismiss() {
         print("WriteViewController 모달이 닫혔습니다.")
-        viewModel.reloadHanhdam() // 데이터 갱신
+        viewModel.reloadHangdam() // 데이터 갱신
     }
 }
 /// 텍스트 입력 제한을 위해 UITextFieldDelegate 구현.

--- a/Sodam/Sodam/Main/View/MainViewController.swift
+++ b/Sodam/Sodam/Main/View/MainViewController.swift
@@ -98,7 +98,6 @@ final class MainViewController: UIViewController {
     // 작성화면 모달 띄우는 메서드
     private func modalWriteViewController(with name: String) {
         let writeViewController = WriteViewController(writeViewModel: writeViewModel)
-        writeViewController.hangdamName = name                                  // 지어진 이름 작성화면으로 전달
         writeViewController.delegate = self                                     // Delegate 연결
         writeViewController.modalTransitionStyle = .coverVertical               // 모달 스타일 설정
         present(writeViewController, animated: true)                            // 모달 표시
@@ -120,7 +119,6 @@ final class MainViewController: UIViewController {
         if let name = viewModel.hangdam.name {
             // 이미 저장된 이름이 있는 경우에 바로 작성화면으로 이동
             print("저장된 이름으로 작성화면 이동함: \(name)")
-            modalWriteViewController(with: name)
             proceedWithWriting(name: name)
         } else {
             // 저장된 이름이 없는 경우 알림창 표시
@@ -134,7 +132,6 @@ final class MainViewController: UIViewController {
                 }
                 viewModel.saveNewName(as: name) // 새 이름 저장
                 print("입력 된 이름: \(name)")
-                self.modalWriteViewController(with: name) // 작성 화면으로 이동
                 self.proceedWithWriting(name: name)
             }
         }

--- a/Sodam/Sodam/Main/View/MainViewModel.swift
+++ b/Sodam/Sodam/Main/View/MainViewModel.swift
@@ -14,6 +14,10 @@ final class MainViewModel: ObservableObject {
     @Published var hangdam: HangdamDTO // 현재 관리할 행담이 데이터
     @Published var message: String = "" // 화면에 표시할 메시지
     
+    /// 메시지 분기를 위한 플래그 변수
+    private var showLevel5Message: Bool = false
+    private var blockRandomMessage: Bool = false
+    
     // 행담이 데이터 저장 및 불러오는 레포지토리
     private let hangdamRepository: HangdamRepository
     
@@ -33,14 +37,16 @@ final class MainViewModel: ObservableObject {
         reloadHangdam()
     }
     
-    /// 행담이 이름 유무에 따라 화면 메세지를 업데이트 함
+    /// 플래그 변수와 이름이 없는 경우를 검사 후 메시지 업데이트
     func updateMessage() {
-        if let _ = hangdam.name {
-            message = MainMessages.getRandomMessage()
-            print("이름이 지어졌음. 랜덤 메시지 표시")
-        } else {
+        if showLevel5Message {
+            showLevel5Message = false
+        } else if hangdam.name == nil {
             message = MainMessages.firstMessage
-            print("이름이 없음. 부화 메시지 표시")
+        } else if blockRandomMessage {
+            blockRandomMessage = false
+        } else {
+            message = MainMessages.getRandomMessage()
         }
     }
     
@@ -75,8 +81,14 @@ final class MainViewModel: ObservableObject {
         // 디버깅
         print("행담이 레벨 \(level)로 성장함")
         
-        // 레벨에 따른 메세지를 업데이트
-        message = MainMessages.messageForLevel(level, name: hangdam.name ?? "")
+        // message update
+        message = MainMessages.messageForLevel(level, name: hangdam.name ?? "행담이")
+        
+        // write view modal이 닫히면서 random message로 덮이지 않도록 플래그 처리
+        blockRandomMessage = true
+        if level == 5 {
+            showLevel5Message = true
+        }
     }
     
     /// deinit 시 observing 해제

--- a/Sodam/Sodam/Main/View/MainViewModel.swift
+++ b/Sodam/Sodam/Main/View/MainViewModel.swift
@@ -17,7 +17,6 @@ final class MainViewModel: ObservableObject {
     // 행담이 데이터 저장 및 불러오는 레포지토리
     private let hangdamRepository: HangdamRepository
     
-
     init(repository: HangdamRepository) {
     /// 뷰모델 초기화 메서드
         self.hangdamRepository = repository
@@ -29,9 +28,9 @@ final class MainViewModel: ObservableObject {
     }
     
     /// 새로운 이름을 현재 행담이에 저장
-    func saveNewName(as name: String ) {
+    func saveNewName(as name: String) {
         hangdamRepository.nameHangdam(id: hangdam.id, name: name)
-        reloadHanhdam()
+        reloadHangdam()
     }
     
     /// 행담이 이름 유무에 따라 화면 메세지를 업데이트 함
@@ -46,7 +45,7 @@ final class MainViewModel: ObservableObject {
     }
     
     /// 레포지토리에서 현재 행담이 데이터를 다시 불러옴
-    func reloadHanhdam() {
+    func reloadHangdam() {
         self.hangdam = hangdamRepository.getCurrentHangdam()
     }
     

--- a/Sodam/Sodam/Main/View/MainViewModel.swift
+++ b/Sodam/Sodam/Main/View/MainViewModel.swift
@@ -49,11 +49,6 @@ final class MainViewModel: ObservableObject {
         self.hangdam = hangdamRepository.getCurrentHangdam()
     }
     
-    /// 현재 행담이의 ID를 반환함
-    func getCurrentHangdamID() -> String {
-        return hangdamRepository.getCurrentHangdam().id
-    }
-    
     // MARK: - TodayWriteUserDefaults(테스트 하는 동안 주석처리)
     
     /// 오늘 작성했는지 확인하는 메서드

--- a/Sodam/Sodam/WriteView/WriteView.swift
+++ b/Sodam/Sodam/WriteView/WriteView.swift
@@ -144,15 +144,6 @@ class WriteView: UIView {
             topBar
         ].forEach { addSubview($0) }
         
-//        dateLabel.layer.borderWidth = 1
-//        textView.layer.borderWidth = 1
-//        collectionView.layer.borderWidth = 1
-//        cameraButton.layer.borderWidth = 1
-//        imageButton.layer.borderWidth = 1
-//        dismisslButton.layer.borderWidth = 1
-//        submitButton.layer.borderWidth = 1
-//        containerView.layer.borderWidth = 1
-        
         // 바 제약 조건 설정
         topBar.snp.makeConstraints { make in
             make.top.equalTo(safeAreaLayoutGuide.snp.top).offset(20)

--- a/Sodam/Sodam/WriteView/WriteViewController.swift
+++ b/Sodam/Sodam/WriteView/WriteViewController.swift
@@ -15,7 +15,6 @@ protocol WriteViewControllerDelegate: AnyObject {
 final class WriteViewController: UIViewController {
     
     weak var delegate: WriteViewControllerDelegate?
-    var hangdamName: String?
     
     private let writeViewModel: WriteViewModel
     private let writeView = WriteView()

--- a/Sodam/Sodam/WriteView/WriteViewController.swift
+++ b/Sodam/Sodam/WriteView/WriteViewController.swift
@@ -26,9 +26,7 @@ final class WriteViewController: UIViewController {
     }
     
     required init?(coder: NSCoder) {
-        let writeModel = WriteModel()
-        self.writeViewModel = WriteViewModel(writeModel: writeModel, hangdamID: "")
-        super.init(coder: coder)
+        fatalError("init(coder:) has not been implemented")
     }
     
     // MARK: - 뷰 생명주기

--- a/Sodam/Sodam/WriteView/WriteViewModel.swift
+++ b/Sodam/Sodam/WriteView/WriteViewModel.swift
@@ -19,13 +19,13 @@ final class WriteViewModel: NSObject {
     
     var isPostSubmitted: Bool = false // 작성 완료, 임시 저장 구분하기 위한 Bool 타입 변수. 첫 작성을 고려하여 초기값은 false
     
-    init(writeModel: WriteModel,
+    init(writeModel: WriteModel = .init(),
          repository: HappinessRepository = HappinessRepository(),
-         hangdamID: String
+         currentHangdamID: String
     ) {
         self.writeModel = writeModel
         self.happinessRepository = repository
-        self.currentHangdamID = hangdamID
+        self.currentHangdamID = currentHangdamID
         super.init()
     }
     


### PR DESCRIPTION
## 1. 요약
- 보관된 행담이의 기억을 삭제해도 레벨이 down되지 않게 처리
- 행담이 새로 생성되었을 때 기록한 행복이 이미 보관된 행담이에게 추가되는 버그 수정
- `Main` 화면에서 레벨업 상황과 이름이 없는 경우를 제외하고 랜덤 메시지 출력되도록 처리
- 행담이 상태뷰, 행담이 보관함에서 `endDate`까지 표시되어 텍스트가 길어지는 경우 폰트 크기가 작아지도록 처리
## 2. 스크린샷 
| before | after |
| ----- | ----- |
| ![Screenshot 2025-02-03 at 20 23 51](https://github.com/user-attachments/assets/830005e7-59a1-496f-8bf8-9e41cf31c194) | ![Screenshot 2025-02-03 at 20 24 19](https://github.com/user-attachments/assets/19fc6573-c36c-46bc-a430-053f1b81d010) |

## 3. 공유사항
