### PR TITLE
[Fix] WriteViewController 메모리 누수 해결

### DIFF
--- a/Sodam/Sodam/Extension/+Notification.swift
+++ b/Sodam/Sodam/Extension/+Notification.swift
@@ -9,4 +9,5 @@ import Foundation
 
 extension Notification {
     static let levelUP = Notification.Name("levelUP")
+    static let didWriteToday = Notification.Name("DidWriteToday")
 }

--- a/Sodam/Sodam/Main/View/MainViewController.swift
+++ b/Sodam/Sodam/Main/View/MainViewController.swift
@@ -40,7 +40,7 @@ final class MainViewController: UIViewController {
         addGesture()               // 이미지 탭 제스처 설정
         
         // 작성 완료 알림 감지하여 버튼 상태 갱신
-//        NotificationCenter.default.addObserver(self, selector: #selector(didWriteToday), name: Notification.Name("DidWriteToday"), object: nil)
+//        NotificationCenter.default.addObserver(self, selector: #selector(didWriteToday), name: Notification.didWriteToday, object: nil)
     }
     
     /// 뷰가 다시 나타날 때 데이터 갱신

--- a/Sodam/Sodam/WriteView/WriteViewController.swift
+++ b/Sodam/Sodam/WriteView/WriteViewController.swift
@@ -213,7 +213,7 @@ final class WriteViewController: UIViewController {
             // WriteViewModel에 작성 완료 이벤트 전달
             self.writeViewModel.submitPost {
                 // 글이 정상적으로 작성된 경우에만 기록 저장
-                NotificationCenter.default.post(name: Notification.Name("DidWriteToday"), object: nil)
+                NotificationCenter.default.post(name: Notification.didWriteToday, object: nil)
                 // 모달 닫기
                 self.dismiss(animated: true, completion: nil)
             }

--- a/Sodam/Sodam/WriteView/WriteViewController.swift
+++ b/Sodam/Sodam/WriteView/WriteViewController.swift
@@ -209,13 +209,13 @@ final class WriteViewController: UIViewController {
         }
         
         // 작성 완료 알림 표시
-        showCompletionAlert {
+        showCompletionAlert { [weak self] in
             // WriteViewModel에 작성 완료 이벤트 전달
-            self.writeViewModel.submitPost {
+            self?.writeViewModel.submitPost {
                 // 글이 정상적으로 작성된 경우에만 기록 저장
                 NotificationCenter.default.post(name: Notification.didWriteToday, object: nil)
                 // 모달 닫기
-                self.dismiss(animated: true, completion: nil)
+                self?.dismiss(animated: true, completion: nil)
             }
         }
     }


### PR DESCRIPTION
## 1. 요약
시연님이 Xcode Instruments로 발견하신 메모리 누수 해결했습니다. 작성 완료 alert의 completion에 [weak self] 약한 참조 처리 했습니다.
## 2. 스크린샷 
## 3. 공유사항
