### PR TITLE
[Fix] 앱 첫 진입 후 사용자가 알림 시간설정은 안한상태일때 기본 시간 설정 (저녁 9시)

### DIFF
--- a/Sodam/Sodam/Delegate/AppDelegate.swift
+++ b/Sodam/Sodam/Delegate/AppDelegate.swift
@@ -12,39 +12,15 @@ import UserNotifications
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        let center = UNUserNotificationCenter.current()
+        center.delegate = self
         
-        let center = UNUserNotificationCenter.current() // 알림센터 가져오기
-        center.delegate = self // 앱 실행 시 사용자에게 알림 허용 권한을 받음
-        
-        // 현재 알림 권한 상태를 먼저 확인
-        center.getNotificationSettings { settings in
-            DispatchQueue.main.async { // UI 변경은 반드시 메인 스레드에서 실행
-                switch settings.authorizationStatus {
-                case .notDetermined:
-                    // 권한 요청 (사용자가 한 번도 응답하지 않은 상태)
-                    self.requestNotificationAuthorization()
-                case .denied:
-                    // 권한 허용 거부된 경우 → UserDefaultsManager로 중복 표시 방지
-                    if !UserDefaultsManager.shared.getNotificaionAuthorizationStatus() {
-                        self.showToast(message: "알림 권한이 거부되었습니다.")
-                        UserDefaultsManager.shared.saveNotificaionAuthorizationStatus(true) // 최초 한 번만 저장
-                    }
-                case .authorized, .provisional, .ephemeral:
-                    // 권한이 이미 허용된 경우 (다시 요청할 필요 없음)
-                    if !UserDefaultsManager.shared.getNotificaionAuthorizationStatus() {
-                        UserDefaultsManager.shared.saveNotificaionAuthorizationStatus(true)
-                    }
-                @unknown default:
-                    break
-                }
-            }
-        }
-        
+        // 초기 설정 체크 추가
+        checkInitialSetup()
         return true
     }
 
     // MARK: UISceneSession Lifecycle
-
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
         // Called when a new scene session is being created.
         // Use this method to select a configuration to create the new scene with.
@@ -55,44 +31,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Called when the user discards a scene session.
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
-    }
-    
-    // 앱 첫 진입시 권한 허용 여부에 따른 토스트 알림
-    private func requestNotificationAuthorization() {
-        let center = UNUserNotificationCenter.current()
-        let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]  // 필요한 알림 권한을 설정
-        
-        center.requestAuthorization(options: authOptions) { success, error in
-            DispatchQueue.main.async { // UI 변경은 반드시 메인 스레드에서 실행
-                if let error = error {
-                    print("알림 권한 요청 중 에러 발생: \(error.localizedDescription)")
-                    return
-                }
-                
-                if success {
-                    print("알림 권한이 허용되었습니다.")
-                    // 1초 후에 토스트 메시지 띄우기
-                    self.showToast(message: "알림 시간 설정이 가능합니다.")
-                    UserDefaultsManager.shared.saveNotificaionAuthorizationStatus(true)
-                } else {
-                    print("알림 권한이 거부되었습니다.")
-                    // 1초 후에 토스트 메시지 띄우기
-                    self.showToast(message: "알림 권한이 거부되었습니다.")
-                    UserDefaultsManager.shared.saveNotificaionAuthorizationStatus(true)
-                }
-            }
-        }
-    }
-    
-    // 안전하게 토스트 메시지를 표시하는 함수
-    private func showToast(message: String) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-            // 현재 최상위 윈도우의 rootViewController의 view에서 토스트 표시(화면전환될때도 토스트 유지)
-            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-               let keyWindow = windowScene.windows.first(where: { $0.isKeyWindow }) {
-                keyWindow.rootViewController?.view.showToast(message: message)
-            }
-        }
     }
 }
 
@@ -112,5 +50,89 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     // Background에서 알림 클릭 시 처리사용자가 알림을 탭했을때 해당 메서드 호출
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
         completionHandler()  // 응답 처리가 완료되었음을 시스템에 알림
+    }
+}
+
+// MARK: - Private Methods
+
+private extension AppDelegate {
+    // 초기 설정 체크 추가
+    func checkInitialSetup() {
+        let center = UNUserNotificationCenter.current()
+        center.getNotificationSettings { settings in
+            DispatchQueue.main.async { // UI 변경은 반드시 메인 스레드에서 실행
+                switch settings.authorizationStatus {
+                case .notDetermined:
+                    // 권한 요청 (사용자가 한 번도 응답하지 않은 상태)
+                    self.requestNotificationAuthorization()
+                case .denied:
+                    // 권한 허용 거부된 경우 → UserDefaultsManager로 중복 표시 방지
+                    if !UserDefaultsManager.shared.getNotificaionAuthorizationStatus() {
+                        self.showToast(message: "알림 권한이 거부되었습니다.")
+                        UserDefaultsManager.shared.saveNotificaionAuthorizationStatus(true) // 최초 한 번만 저장
+                    }
+                case .authorized, .provisional, .ephemeral:
+                    // 초기 설정이 완료 여부
+                    if !UserDefaultsManager.shared.isNotificationSetupComplete() {
+                        self.setDefaultNotificationTime()
+                        UserDefaultsManager.shared.markNotificationSetupAsComplete()
+                    }
+                    UserDefaultsManager.shared.saveNotificaionAuthorizationStatus(true)
+                @unknown default:
+                    break
+                }
+            }
+        }
+    }
+    
+    // 앱 첫 진입시 디폴트 시간
+    func setDefaultNotificationTime() {
+        let calendar = Calendar.current
+        let defaultTime = calendar.date(bySettingHour: 21, minute: 0, second: 0, of: Date())!
+        UserDefaultsManager.shared.saveNotificationTime(defaultTime)
+        
+        // 로컬 알림 예약
+        LocalNotificationManager.shared.setReservedNotification(defaultTime)
+    }
+    
+    // 앱 첫 진입시 권한 허용 여부에 따른 토스트 알림
+    func requestNotificationAuthorization() {
+        let center = UNUserNotificationCenter.current()
+        let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]  // 필요한 알림 권한을 설정
+        
+        center.requestAuthorization(options: authOptions) { success, error in
+            DispatchQueue.main.async { // UI 변경은 반드시 메인 스레드에서 실행
+                if let error = error {
+                    print("알림 권한 요청 중 에러 발생: \(error.localizedDescription)")
+                    return
+                }
+                
+                if success {
+                    self.showToast(message: "알림 시간 설정이 가능합니다.")
+                    // 최초 설정이 완료되지 않았을 경우 기본 시간 설정
+                    if !UserDefaultsManager.shared.isNotificationSetupComplete() {
+                        self.setDefaultNotificationTime()
+                        UserDefaultsManager.shared.markNotificationSetupAsComplete()
+                    }
+                    UserDefaultsManager.shared.saveNotificaionAuthorizationStatus(true)
+                } else {
+                    print("알림 권한이 거부되었습니다.")
+                    // 1초 후에 토스트 메시지 띄우기
+                    self.showToast(message: "알림 권한이 거부되었습니다.")
+                    UserDefaultsManager.shared.saveNotificaionAuthorizationStatus(true)
+                }
+            }
+        }
+    }
+    
+    // 안전하게 토스트 메시지를 표시하는 함수
+    func showToast(message: String) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            // 현재 최상위 윈도우의 rootViewController의 view에서 토스트 표시(화면전환될때도 토스트 유지)
+            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+               let keyWindow = windowScene.windows.first(where: { $0.isKeyWindow }) {
+                keyWindow.rootViewController?.view.showToast(message: message)
+            }
+        }
     }
 }

--- a/Sodam/Sodam/Delegate/AppDelegate.swift
+++ b/Sodam/Sodam/Delegate/AppDelegate.swift
@@ -64,7 +64,9 @@ private extension AppDelegate {
                 switch settings.authorizationStatus {
                 case .notDetermined:
                     // 권한 요청 (사용자가 한 번도 응답하지 않은 상태)
-                    self.requestNotificationAuthorization()
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { // 1초 후 실행
+                        self.requestNotificationAuthorization()
+                    }
                 case .denied:
                     // 권한 허용 거부된 경우 → UserDefaultsManager로 중복 표시 방지
                     if !UserDefaultsManager.shared.getNotificaionAuthorizationStatus() {

--- a/Sodam/Sodam/Manager/UserDefaultsManager.swift
+++ b/Sodam/Sodam/Manager/UserDefaultsManager.swift
@@ -20,6 +20,7 @@ final class UserDefaultsManager {
         static let content = "content"  // 작성 내용
         static let imagePath = "imagePath"  // 작성시 등록 이미지
         static let notificationAuthorizationStatus = "notificationAuthorizationStatus"  // 앱 첫 진입시 알림 권한 허용 여부 상태
+        static let notificationInitialSetupComplete = "notificationInitialSetupComplete" // 앱 알림 초기 설정 여부 확인
     }
     
     // MARK: - UserDefaults에 저장
@@ -42,6 +43,10 @@ final class UserDefaultsManager {
     
     func saveNotificaionAuthorizationStatus(_ isAuthorized: Bool) {
         userDefaults.set(isAuthorized, forKey: Keys.notificationAuthorizationStatus)
+    }
+    
+    func isNotificationSetupComplete() -> Bool {
+        return userDefaults.bool(forKey: Keys.notificationInitialSetupComplete)
     }
 
     // MARK: - UserDefaults에 저장된 값 얻어오기
@@ -70,5 +75,9 @@ final class UserDefaultsManager {
     
     func getNotificaionAuthorizationStatus() -> Bool {
         return userDefaults.bool(forKey: Keys.notificationAuthorizationStatus)
+    }
+    
+    func markNotificationSetupAsComplete() {
+        userDefaults.set(true, forKey: Keys.notificationInitialSetupComplete)
     }
 }

--- a/Sodam/Sodam/Setting/SettingViewModel/SettingViewModel.swift
+++ b/Sodam/Sodam/Setting/SettingViewModel/SettingViewModel.swift
@@ -64,24 +64,31 @@ private extension SettingViewModel {
     func checkNotificationAuthorization() {
         UNUserNotificationCenter.current().getNotificationSettings { settings in
             DispatchQueue.main.async {
-                // 권한 여부 체크
-                if settings.authorizationStatus != .authorized {
-                    // 권한 없으면 스위치 OFF로 설정
+                if settings.authorizationStatus == .authorized {
+                    // ✅ 권한 허용 시 항상 실행되는 로직
+                    self.handleAuthorizedState()
+                } else {
                     self.isToggleOn = false
                     self.saveIsToggleNotification(false)
-                } else {
-                    // 권한 있으면 스위치 ON으로 설정
-                    self.isToggleOn = true
-                    self.saveIsToggleNotification(true)
-                    
-                    // 만약 앱 첫 진입 시 알림 허용, 사용자가 알림 설정은 안한상태일때 기본 시간 설정 (저녁 9시)
-                    if self.getNotificationTime() == nil {
-                        let defaultTime = Calendar.current.date(bySettingHour: 21, minute: 0, second: 0, of: Date())!
-                        self.saveNotificationTime(defaultTime)
-                        self.setReservedNotificaion(defaultTime)
-                    }
                 }
             }
         }
+    }
+    
+    func handleAuthorizedState() {
+        // ✅ 최초 권한 허용인 경우에만 기본 시간 설정
+        if !UserDefaultsManager.shared.isNotificationSetupComplete() {
+            let defaultTime = Calendar.current.date(
+                bySettingHour: 21,
+                minute: 0,
+                second: 0,
+                of: Date()
+            )!
+            self.saveNotificationTime(defaultTime)
+            UserDefaultsManager.shared.markNotificationSetupAsComplete()
+        }
+        
+        self.isToggleOn = true
+        self.saveIsToggleNotification(true)
     }
 }

--- a/Sodam/Sodam/Setting/SettingViewModel/SettingViewModel.swift
+++ b/Sodam/Sodam/Setting/SettingViewModel/SettingViewModel.swift
@@ -11,7 +11,7 @@ final class SettingViewModel {
     private let userDefaultsManager = UserDefaultsManager.shared
     private let localNotificationManager = LocalNotificationManager.shared
     
-    var isSwitchOn: Bool = false
+    var isToggleOn: Bool = false
     let sectionType: [Setting.SetSection] = [.appSetting, .develop]
     var version: String? {
         guard let dictionary = Bundle.main.infoDictionary,
@@ -25,8 +25,8 @@ final class SettingViewModel {
     
     // MARK: - Initializer
     init() {
-        // 앱 시작 시 UserDefaults에서 값 로드
-        self.isSwitchOn = userDefaultsManager.getNotificaionAuthorizationStatus()
+        self.isToggleOn = userDefaultsManager.getNotificaionAuthorizationStatus()
+        self.checkNotificationAuthorization()
     }
     
     func saveNotificationTime(_ sender: Date) {
@@ -56,5 +56,32 @@ final class SettingViewModel {
             return
         }
         UIApplication.shared.open(url, options: [:], completionHandler: nil)
+    }
+}
+
+private extension SettingViewModel {
+    // 알림 권한을 확인하고 초기 설정
+    func checkNotificationAuthorization() {
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            DispatchQueue.main.async {
+                // 권한 여부 체크
+                if settings.authorizationStatus != .authorized {
+                    // 권한 없으면 스위치 OFF로 설정
+                    self.isToggleOn = false
+                    self.saveIsToggleNotification(false)
+                } else {
+                    // 권한 있으면 스위치 ON으로 설정
+                    self.isToggleOn = true
+                    self.saveIsToggleNotification(true)
+                    
+                    // 만약 앱 첫 진입 시 알림 허용, 사용자가 알림 설정은 안한상태일때 기본 시간 설정 (저녁 9시)
+                    if self.getNotificationTime() == nil {
+                        let defaultTime = Calendar.current.date(bySettingHour: 21, minute: 0, second: 0, of: Date())!
+                        self.saveNotificationTime(defaultTime)
+                        self.setReservedNotificaion(defaultTime)
+                    }
+                }
+            }
+        }
     }
 }

--- a/Sodam/Sodam/Setting/SettingsViewController.swift
+++ b/Sodam/Sodam/Setting/SettingsViewController.swift
@@ -73,20 +73,38 @@ private extension SettingsViewController {
     @objc func checkNotificationPermissionAndUpdateSwitch() {
         UNUserNotificationCenter.current().getNotificationSettings { settings in
             DispatchQueue.main.async {
-                if settings.authorizationStatus != .authorized {
-                    // 권한이 거부된 경우, 스위치를 OFF로 설정
-                    self.settingViewModel.isToggleOn = false
-                    self.settingViewModel.saveIsToggleNotification(false)
-                } else {
-                    // 권한이 허용된 경우, 스위치를 ON으로 설정
+                _ = !self.settingViewModel.isToggleOn // 이전 상태 확인
+                let isAuthorizedNow = settings.authorizationStatus == .authorized
+                
+                if isAuthorizedNow {
+                    // 사용자가 설정에서 알림을 허용했을 경우
                     self.settingViewModel.isToggleOn = true
                     self.settingViewModel.saveIsToggleNotification(true)
+                    
+                    if self.settingViewModel.getNotificationTime() == nil {
+                        // 기존에 저장된 알림 시간이 없으면 기본값(21:00) 설정
+                        let defaultTime = self.defaultNotificationTime()
+                        self.settingViewModel.saveNotificationTime(defaultTime)
+                        self.settingViewModel.setReservedNotificaion(defaultTime)
+                    }
+                } else {
+                    // 여전히 거부 상태면 스위치를 OFF로 유지
+                    self.settingViewModel.isToggleOn = false
+                    self.settingViewModel.saveIsToggleNotification(false)
                 }
                 
-                // 스위치 상태에 따라 UI 업데이트
+                // UI 업데이트
                 self.settingView.tableView.reloadSections(IndexSet(integer: 0), with: .automatic)
             }
         }
+    }
+    
+    // 기본 시간(21:00) 반환하는 함수
+    private func defaultNotificationTime() -> Date {
+        var components = DateComponents()
+        components.hour = 21
+        components.minute = 0
+        return Calendar.current.date(from: components) ?? Date()
     }
 }
 

--- a/Sodam/Sodam/Setting/SettingsViewController.swift
+++ b/Sodam/Sodam/Setting/SettingsViewController.swift
@@ -30,6 +30,20 @@ final class SettingsViewController: UIViewController {
         view.backgroundColor = .viewBackground
         setupTableView()
         setupScheduledNotification()
+        
+        // 앱이 포그라운드로 돌아올 때마다 알림 권한 확인
+        NotificationCenter.default.addObserver(self, selector: #selector(checkNotificationPermissionAndUpdateSwitch), name: UIApplication.willEnterForegroundNotification, object: nil)
+    }
+    
+    deinit {
+            NotificationCenter.default.removeObserver(self)
+        }
+        
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        // 알림 권한 상태를 다시 체크하여 스위치 상태를 업데이트
+        checkNotificationPermissionAndUpdateSwitch()
     }
 }
 
@@ -45,11 +59,32 @@ private extension SettingsViewController {
     }
     
     func setupScheduledNotification() {
-        // UserDefaults에서 알림 상태 복원 (이미 뷰모델에서 초기화했으므로 중복 처리 없음)
-        if settingViewModel.isSwitchOn {
+        // UserDefaults에서 알림 상태 체크
+        if settingViewModel.isToggleOn {
             if let savedTime = settingViewModel.getNotificationTime() {
                 print("savedTime \(savedTime)")
                 settingViewModel.setReservedNotificaion(savedTime)
+            }
+        }
+        // 알림 토글 상태에 따라 UI 업데이트
+        settingView.tableView.reloadSections(IndexSet(integer: 0), with: .automatic)
+    }
+    
+    @objc func checkNotificationPermissionAndUpdateSwitch() {
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            DispatchQueue.main.async {
+                if settings.authorizationStatus != .authorized {
+                    // 권한이 거부된 경우, 스위치를 OFF로 설정
+                    self.settingViewModel.isToggleOn = false
+                    self.settingViewModel.saveIsToggleNotification(false)
+                } else {
+                    // 권한이 허용된 경우, 스위치를 ON으로 설정
+                    self.settingViewModel.isToggleOn = true
+                    self.settingViewModel.saveIsToggleNotification(true)
+                }
+                
+                // 스위치 상태에 따라 UI 업데이트
+                self.settingView.tableView.reloadSections(IndexSet(integer: 0), with: .automatic)
             }
         }
     }
@@ -69,7 +104,7 @@ extension SettingsViewController: UITableViewDataSource, UITableViewDelegate {
         
         switch sectionType {
         case .appSetting:
-            return settingViewModel.isSwitchOn ? 2 : 1
+            return settingViewModel.isToggleOn ? 2 : 1
         case .develop:
             return 2
         }
@@ -103,21 +138,18 @@ extension SettingsViewController: UITableViewDataSource, UITableViewDelegate {
             if indexPath.row == 0 {
                 // 첫 번째 셀: 알림 설정
                 cell.configure(title: Setting.SetCell.notification.rawValue, switchAction: #selector(didToggleSwitch(_:)), timeAction: nil, version: "")
-                cell.switchButton.isOn = settingViewModel.isSwitchOn
-            } else if indexPath.row == 1 && settingViewModel.isSwitchOn {
+                cell.switchButton.isOn = settingViewModel.isToggleOn
+            } else if indexPath.row == 1 && settingViewModel.isToggleOn {
                 // 두 번째 셀: 시간 설정 (스위치가 켜졌을 때만 표시)
                 cell.configure(title: Setting.SetCell.setTime.rawValue, switchAction: nil, timeAction: #selector(userScheduleNotification), version: "")
                 cell.titleLabel.textColor = .black
                 cell.timePicker.isHidden = false
                 cell.switchButton.isHidden = true
                 
-                // 저장된 시간이 있으면 설정
                 if let savedTime = settingViewModel.getNotificationTime() {
-                    print("savedTimeCell \(savedTime)")
                     cell.timePicker.date = savedTime
                 }
             }
-            
         case .develop:
             cell.timePicker.isHidden = true
             cell.switchButton.isHidden = true
@@ -126,7 +158,6 @@ extension SettingsViewController: UITableViewDataSource, UITableViewDelegate {
             if indexPath.row == 0 {
                 cell.versionLabel.isHidden = true
                 cell.arrowImage.isHidden = false
-
                 cell.configure(title: Setting.SetCell.appReview.rawValue, switchAction: nil, timeAction: nil, version: "")
             } else if indexPath.row == 1 {
                 cell.versionLabel.isHidden = false
@@ -172,10 +203,8 @@ extension SettingsViewController: UITableViewDataSource, UITableViewDelegate {
         settingViewModel.saveNotificationTime(sender.date)
         print("sender.date11 \(sender.date)")
 
-        if settingViewModel.isSwitchOn {
+        if settingViewModel.isToggleOn {
             settingViewModel.setReservedNotificaion(sender.date)
-            print("sender.date22 \(sender.date)")
-
         }
     }
     
@@ -207,7 +236,7 @@ extension SettingsViewController: UITableViewDataSource, UITableViewDelegate {
     
     // 권한이 허용된 경우 알림 울리도록 설정 (토글이 켜졌을 때 실행)
     private func handleNotificationToggle(isOn: Bool) {
-        settingViewModel.isSwitchOn = isOn
+        settingViewModel.isToggleOn = isOn
         settingViewModel.saveIsToggleNotification(isOn)
         
         if isOn {


### PR DESCRIPTION
## 1. 요약 
알림 권한 설정 내용 추가

## 2. 스크린샷 

## 3. 공유사항
1. 알림권한 허용안한상태로 앱 첫진입시와 재진입했을 경우 디폴트가 토글 off
2. 알림권한 허용 된 상태일때 앱 첫 진입시에는 사용자가 설정 안한상태에는 디폴트가 토글 on, 알림시간은 21:00
3. 알림권한 허용 된 상태일때 아이폰설정에서 알림허용 off 후 앱 진입시 앱내 설정 off
4. 앱 내 설정 off 시 시간 셀 숨김 안되는 오류 수정
5. 앱 첫 진입시 알림 허용, 이후 앱내 알림 토글 off 로 하고 다시 On 했을때 설정으로 이동하는 알럿이 안뜨도록 설정

✅ 런치스크린 종료 시 토스트가 깜빡이는 이슈 해결 계획

**현재이슈**
- AppDelegate에서 알림 권한 팝업을 일정 시간 후 실행하도록 설정하여 런치스크린 종료 후 토스트가 깜빡이는 문제를 방지함.

**추후수정**
- 현재 런치스크린이 사라질 때 토스트 팝업이 깜빡이는 문제가 발생하여, 팀원 및 튜터님과 논의 후 리팩토링을 적용하기로 결정
- 권한 팝업을 AppDelegate가 아닌 MainViewController에서 처리하도록 수정 예정
- 알림 권한 요청 로직을 LocalNotificationManager에서 관리하도록 변경
- 런치스크린과 권한 팝업이 겹치지 않도록 더 안정적인 방식으로 개선

리팩토링을 통해 더 구조적으로 정리하고, 사용자가 자연스럽게 권한 요청을 경험하도록 개선할 예정입니담!
