### PR TITLE
[Fix] 작성뷰 레이아웃 수정

### DIFF
--- a/Sodam/Sodam/View/Main/WriteView/WriteView.swift
+++ b/Sodam/Sodam/View/Main/WriteView/WriteView.swift
@@ -109,6 +109,9 @@ class WriteView: UIView {
         return view
     }()
     
+    // 버튼을 담을 컨테이너 뷰
+    private let containerView: UIView = UIView()
+    
     // MARK: - 초기화
     
     override init(frame: CGRect) {
@@ -128,23 +131,10 @@ extension WriteView {
     private func setupUI() {
         backgroundColor = .viewBackground
         
-        let containerView: UIView = UIView()
-        [
-            collectionView,
-            cameraButton,
-            imageButton,
-            submitButton,
-        ].forEach { containerView.addSubview($0) }
-
-        [
-            dateLabel,
-            textView,
-            placeholderLabel,
-            dismisslButton,
-            containerView,
-            topBar
-        ].forEach { addSubview($0) }
+        containerView.addSubViews([cameraButton, imageButton, submitButton])
         
+        self.addSubViews([dateLabel, textView, placeholderLabel, collectionView, dismisslButton, containerView, topBar])
+
         // 바 제약 조건 설정
         topBar.snp.makeConstraints { make in
             make.top.equalTo(safeAreaLayoutGuide.snp.top).offset(20)
@@ -165,26 +155,26 @@ extension WriteView {
             make.trailing.equalTo(safeAreaLayoutGuide.snp.trailing).offset(-20)
         }
         
+        containerView.snp.makeConstraints { make in
+            make.leading.trailing.equalTo(safeAreaLayoutGuide).inset(20)
+            make.height.equalTo(safeAreaLayoutGuide.snp.height).multipliedBy(0.05)
+            containerBottomConstraint = make.bottom.equalTo(safeAreaLayoutGuide.snp.bottom).constraint
+        }
+        
+        collectionView.snp.makeConstraints { make in
+            make.leading.trailing.equalTo(safeAreaLayoutGuide).inset(20)
+            make.height.equalTo(safeAreaLayoutGuide.snp.width).multipliedBy(0.25)
+            make.bottom.equalTo(containerView.snp.top)
+        }
+        
         textView.snp.makeConstraints { make in
             make.top.equalTo(dateLabel.snp.bottom).offset(20)
-            make.height.equalTo(safeAreaLayoutGuide.snp.height).multipliedBy(0.6)
+            make.bottom.equalTo(collectionView.snp.top)
             make.leading.trailing.equalTo(safeAreaLayoutGuide).inset(20)
         }
         
         placeholderLabel.snp.makeConstraints { make in
             make.top.leading.equalTo(textView).offset(8)
-        }
-        
-        containerView.snp.makeConstraints { make in
-            make.leading.trailing.equalTo(safeAreaLayoutGuide).inset(20)
-            make.height.equalTo(safeAreaLayoutGuide.snp.height).multipliedBy(0.20)
-            containerBottomConstraint = make.bottom.equalTo(safeAreaLayoutGuide).inset(60).constraint
-        }
-        
-        collectionView.snp.makeConstraints { make in
-            make.top.equalToSuperview()
-            make.leading.trailing.equalTo(safeAreaLayoutGuide).inset(20)
-            make.height.equalTo(safeAreaLayoutGuide.snp.width).multipliedBy(0.25)
         }
         
         cameraButton.snp.makeConstraints { make in

--- a/Sodam/Sodam/View/Main/WriteView/WriteView.swift
+++ b/Sodam/Sodam/View/Main/WriteView/WriteView.swift
@@ -158,7 +158,7 @@ extension WriteView {
         containerView.snp.makeConstraints { make in
             make.leading.trailing.equalTo(safeAreaLayoutGuide).inset(20)
             make.height.equalTo(safeAreaLayoutGuide.snp.height).multipliedBy(0.05)
-            containerBottomConstraint = make.bottom.equalTo(safeAreaLayoutGuide.snp.bottom).constraint
+            containerBottomConstraint = make.bottom.equalTo(safeAreaLayoutGuide.snp.bottom).inset(60).constraint
         }
         
         collectionView.snp.makeConstraints { make in
@@ -212,6 +212,36 @@ extension WriteView {
     // 컬렉션뷰 리로드 메서드
     func collectionViewReload() {
         collectionView.reloadData()
+    }
+    
+    func updateCollectionViewConstraint(_ isHidden: Bool) {
+        if isHidden {
+            collectionView.snp.remakeConstraints { make in
+                make.height.equalTo(0)
+            }
+            collectionView.isHidden = isHidden
+            
+            textView.snp.remakeConstraints { make in
+                make.top.equalTo(dateLabel.snp.bottom).offset(20)
+                make.leading.trailing.equalTo(safeAreaLayoutGuide).inset(20)
+                make.bottom.equalTo(containerView.snp.top)
+            }
+        } else {
+            collectionView.snp.remakeConstraints { make in
+                make.leading.trailing.equalTo(safeAreaLayoutGuide).inset(20)
+                make.height.equalTo(safeAreaLayoutGuide.snp.width).multipliedBy(0.25)
+                make.bottom.equalTo(containerView.snp.top)
+            }
+            collectionView.isHidden = isHidden
+            
+            textView.snp.remakeConstraints { make in
+                make.top.equalTo(dateLabel.snp.bottom).offset(20)
+                make.bottom.equalTo(collectionView.snp.top)
+                make.leading.trailing.equalTo(safeAreaLayoutGuide).inset(20)
+            }
+        }
+        
+        self.layoutIfNeeded()
     }
 }
 

--- a/Sodam/Sodam/View/Main/WriteView/WriteView.swift
+++ b/Sodam/Sodam/View/Main/WriteView/WriteView.swift
@@ -215,11 +215,12 @@ extension WriteView {
     }
     
     func updateCollectionViewConstraint(_ isHidden: Bool) {
+        collectionView.isHidden = isHidden
+        
         if isHidden {
             collectionView.snp.remakeConstraints { make in
                 make.height.equalTo(0)
             }
-            collectionView.isHidden = isHidden
             
             textView.snp.remakeConstraints { make in
                 make.top.equalTo(dateLabel.snp.bottom).offset(20)
@@ -232,7 +233,6 @@ extension WriteView {
                 make.height.equalTo(safeAreaLayoutGuide.snp.width).multipliedBy(0.25)
                 make.bottom.equalTo(containerView.snp.top)
             }
-            collectionView.isHidden = isHidden
             
             textView.snp.remakeConstraints { make in
                 make.top.equalTo(dateLabel.snp.bottom).offset(20)

--- a/Sodam/Sodam/View/Main/WriteView/WriteView.swift
+++ b/Sodam/Sodam/View/Main/WriteView/WriteView.swift
@@ -120,9 +120,10 @@ class WriteView: UIView {
         super.init(coder: coder)
         setupUI()
     }
-    
-    // MARK: - UI 셋업
-    
+}
+
+// MARK: - UI 레이아웃 메서드
+extension WriteView {
     // UI 셋업
     private func setupUI() {
         backgroundColor = .viewBackground
@@ -205,26 +206,35 @@ class WriteView: UIView {
         }
     }
     
-    // MARK: - UI 접근 메서드
-    
     // 하단 UI constraints 조절 메서드
     func updateContainerBottomConstraint(inset: CGFloat) {
         containerBottomConstraint?.update(inset: inset)
     }
-    
+}
+
+// MARK: - 컬렉션뷰 메서드
+extension WriteView {
     // 컬렉션뷰 dataSource 설정 메서드
     func setCollectionViewDataSource(dataSource: UICollectionViewDataSource) {
         collectionView.dataSource = dataSource
     }
     
+    // 컬렉션뷰 리로드 메서드
+    func collectionViewReload() {
+        collectionView.reloadData()
+    }
+}
+
+// MARK: - 텍스트뷰 메서드
+extension WriteView {
+    // placeholder 숨김처리 메서드
+    private func updatePlaceholderVisibility() {
+        placeholderLabel.isHidden = !textView.text.isEmpty
+    }
+    
     // 텍스트뷰 delegate 설정 메서드
     func setTextViewDeleaget(delegate: UITextViewDelegate) {
         textView.delegate = delegate
-    }
-    // 텍스트뷰 내용 변경 메서드
-    func setTextViewText(_ text: String) {
-        textView.text = text
-        updatePlaceholderVisibility() // 텍스트 변경 시 Placeholder 업데이트
     }
     
     // 텍스트뷰 내용 접근 메서드
@@ -232,30 +242,32 @@ class WriteView: UIView {
         return textView.text
     }
     
-    // placeholder 숨김처리 메서드
-    private func updatePlaceholderVisibility() {
-        placeholderLabel.isHidden = !textView.text.isEmpty
+    // 텍스트뷰 내용 변경 메서드
+    func setTextViewText(_ text: String) {
+        textView.text = text
+        updatePlaceholderVisibility() // 텍스트 변경 시 Placeholder 업데이트
     }
-    
+}
+
+// MARK: - 버튼 액션 설정
+extension WriteView {
     // 카메라 버튼 액션 설정 메서드
     func setCameraButtonAction(target: Any, cameraSelector: Selector) {
         cameraButton.addTarget(target, action: cameraSelector, for: .touchUpInside)
     }
+    
     // 사진 버튼 액션 설정 메서드
     func setImageButtonAction(target: Any, imageSelector: Selector) {
         imageButton.addTarget(target, action: imageSelector, for: .touchUpInside)
     }
+    
     // 작성완료 버튼 액션 설정 메서드
     func setSubmitButtonAction(target: Any, submitSelector: Selector) {
         submitButton.addTarget(target, action: submitSelector, for: .touchUpInside)
     }
+    
     // dismiss 버튼 액션 설정 메서드
     func setDismissButtonAction(target: Any, dismissSelector: Selector) {
         dismisslButton.addTarget(target, action: dismissSelector, for: .touchUpInside)
-    }
-    
-    // 컬렉션뷰 리로드 메서드
-    func collectionViewReload() {
-        collectionView.reloadData()
     }
 }

--- a/Sodam/Sodam/View/Main/WriteView/WriteViewController.swift
+++ b/Sodam/Sodam/View/Main/WriteView/WriteViewController.swift
@@ -36,8 +36,8 @@ final class WriteViewController: UIViewController {
         view = writeView
     }
     
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         
         // 임시 저장글 있는지 확인하고 로드
         writeViewModel.loadTemporaryPost()
@@ -96,6 +96,8 @@ final class WriteViewController: UIViewController {
 // MARK: - 컬렉션뷰 DataSource 설정
 extension WriteViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        let imageCount = writeViewModel.images.count
+        writeView.updateCollectionViewConstraint(imageCount == 0)
         return writeViewModel.images.count
     }
     
@@ -237,7 +239,7 @@ extension WriteViewController {
 
         // 동적으로 계산된 inset 적용
         let inset = keyboardHeight - safeAreaBottomInset
-        writeView.updateContainerBottomConstraint(inset: inset)
+        writeView.updateContainerBottomConstraint(inset: inset + 10)
         
         // 업데이트 된 레이아웃 반영
         UIView.animate(withDuration: animationDuration) {
@@ -253,7 +255,7 @@ extension WriteViewController {
         }
         
         // 키보드가 사라지면 컨테이너 뷰의 제약 조건을 원래대로 복원
-        writeView.updateContainerBottomConstraint(inset: 0)
+        writeView.updateContainerBottomConstraint(inset: 60)
         
         UIView.animate(withDuration: animationDuration) {
             self.view.layoutIfNeeded()

--- a/Sodam/Sodam/View/Main/WriteView/WriteViewController.swift
+++ b/Sodam/Sodam/View/Main/WriteView/WriteViewController.swift
@@ -253,7 +253,7 @@ extension WriteViewController {
         }
         
         // 키보드가 사라지면 컨테이너 뷰의 제약 조건을 원래대로 복원
-        writeView.updateContainerBottomConstraint(inset: 60)
+        writeView.updateContainerBottomConstraint(inset: 0)
         
         UIView.animate(withDuration: animationDuration) {
             self.view.layoutIfNeeded()

--- a/Sodam/Sodam/View/Main/WriteView/WriteViewController.swift
+++ b/Sodam/Sodam/View/Main/WriteView/WriteViewController.swift
@@ -90,14 +90,13 @@ final class WriteViewController: UIViewController {
     private func updateUI(with post: Post) {
         writeView.setTextViewText(post.content) // 텍스트뷰 업데이트
         writeView.collectionViewReload() // 컬렉션 뷰 리로드
+        writeView.updateCollectionViewConstraint(writeViewModel.images.isEmpty)
     }
 }
 
 // MARK: - 컬렉션뷰 DataSource 설정
 extension WriteViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        let imageCount = writeViewModel.images.count
-        writeView.updateCollectionViewConstraint(imageCount == 0)
         return writeViewModel.images.count
     }
     

--- a/Sodam/Sodam/View/Main/WriteView/WriteViewController.swift
+++ b/Sodam/Sodam/View/Main/WriteView/WriteViewController.swift
@@ -86,8 +86,45 @@ final class WriteViewController: UIViewController {
         }
     }
     
-    // MARK: - 메서드 선언
+    // UI 업데이트 메서드
+    private func updateUI(with post: Post) {
+        writeView.setTextViewText(post.content) // 텍스트뷰 업데이트
+        writeView.collectionViewReload() // 컬렉션 뷰 리로드
+    }
+}
+
+// MARK: - 컬렉션뷰 DataSource 설정
+extension WriteViewController: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return writeViewModel.images.count
+    }
     
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ImageCollectionViewCell.identifier, for: indexPath) as? ImageCollectionViewCell else {
+            return UICollectionViewCell()
+        }
+        let image = writeViewModel.images[indexPath.item]
+        cell.configure(with: image)
+        
+        // 삭제 클로저 설정
+        cell.onDelete = { [weak self] in
+            self?.writeViewModel.removeImage(at: indexPath.item)
+            collectionView.reloadData()
+        }
+        return cell
+    }
+}
+
+// MARK: - 텍스트뷰 deleage 설정
+extension WriteViewController: UITextViewDelegate {
+    func textViewDidChange(_ textView: UITextView) {
+        // 텍스트가 변경될 때마다 뷰모델에 전달
+        writeViewModel.updateText(textView.text)
+    }
+}
+
+// MARK: - 버튼 액션 메서드
+extension WriteViewController {
     // WriteView에 정의된 버튼들의 액션 설정 메서드
     private func setupActions() {
         writeView.setCameraButtonAction(target: self, cameraSelector: #selector(openCamera))
@@ -95,63 +132,6 @@ final class WriteViewController: UIViewController {
         writeView.setSubmitButtonAction(target: self, submitSelector: #selector(submitText))
         writeView.setDismissButtonAction(target: self, dismissSelector: #selector(tapDismiss))
     }
-    
-    // 키보드 감지
-    private func setupKeyboardNotification() {
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
-    }
-    
-    // 키보드 내리기 구현
-    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        super.touchesBegan(touches, with: event)
-        self.view.endEditing(true) // 키보드 내리기
-    }
-    
-    // 키보드 나타날 때 호출되는 메서드
-    @objc private func keyboardWillShow(_ notification: Notification) {
-        guard let userInfo = notification.userInfo, // 키보드가 나타날 때 프레임 및 애니메이션 시간 정보 저장
-              let keyboardFrame = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect, // 키보드 크기와 위치 저장
-              let animationDuration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? TimeInterval else { // userInfo 중 애니메이션 지속 시간 저장
-            return
-        }
-        
-        // 키보드 높이를 기준으로 inset 설정
-        let keyboardHeight = keyboardFrame.height
-        let safeAreaBottomInset = view.safeAreaInsets.bottom
-
-        // 동적으로 계산된 inset 적용
-        let inset = keyboardHeight - safeAreaBottomInset
-        writeView.updateContainerBottomConstraint(inset: inset)
-        
-        // 업데이트 된 레이아웃 반영
-        UIView.animate(withDuration: animationDuration) {
-            self.view.layoutIfNeeded()
-        }
-    }
-    
-    // 키보드 사라질 때 호출되는 메서드
-    @objc private func keyboardWillHide(_ notification: Notification) {
-        guard let userInfo = notification.userInfo,
-              let animationDuration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? TimeInterval else {
-            return
-        }
-        
-        // 키보드가 사라지면 컨테이너 뷰의 제약 조건을 원래대로 복원
-        writeView.updateContainerBottomConstraint(inset: 60)
-        
-        UIView.animate(withDuration: animationDuration) {
-            self.view.layoutIfNeeded()
-        }
-    }
-    
-    // UI 업데이트 메서드
-    private func updateUI(with post: Post) {
-        writeView.setTextViewText(post.content) // 텍스트뷰 업데이트
-        writeView.collectionViewReload() // 컬렉션 뷰 리로드
-    }
-    
-    // MARK: - 버튼 액션 메서드
     
     // 카메라 버튼 탭할 때 호출되는 메서드
     @objc private func openCamera() {
@@ -227,7 +207,92 @@ final class WriteViewController: UIViewController {
         // 모달 닫기
         dismiss(animated: true, completion: nil)
     }
+}
 
+// MARK: - 키보드 관련 메서드
+extension WriteViewController {
+    // 키보드 감지
+    private func setupKeyboardNotification() {
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    // 키보드 내리기 구현
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesBegan(touches, with: event)
+        self.view.endEditing(true) // 키보드 내리기
+    }
+    
+    // 키보드 나타날 때 호출되는 메서드
+    @objc private func keyboardWillShow(_ notification: Notification) {
+        guard let userInfo = notification.userInfo, // 키보드가 나타날 때 프레임 및 애니메이션 시간 정보 저장
+              let keyboardFrame = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect, // 키보드 크기와 위치 저장
+              let animationDuration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? TimeInterval else { // userInfo 중 애니메이션 지속 시간 저장
+            return
+        }
+        
+        // 키보드 높이를 기준으로 inset 설정
+        let keyboardHeight = keyboardFrame.height
+        let safeAreaBottomInset = view.safeAreaInsets.bottom
+
+        // 동적으로 계산된 inset 적용
+        let inset = keyboardHeight - safeAreaBottomInset
+        writeView.updateContainerBottomConstraint(inset: inset)
+        
+        // 업데이트 된 레이아웃 반영
+        UIView.animate(withDuration: animationDuration) {
+            self.view.layoutIfNeeded()
+        }
+    }
+    
+    // 키보드 사라질 때 호출되는 메서드
+    @objc private func keyboardWillHide(_ notification: Notification) {
+        guard let userInfo = notification.userInfo,
+              let animationDuration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? TimeInterval else {
+            return
+        }
+        
+        // 키보드가 사라지면 컨테이너 뷰의 제약 조건을 원래대로 복원
+        writeView.updateContainerBottomConstraint(inset: 60)
+        
+        UIView.animate(withDuration: animationDuration) {
+            self.view.layoutIfNeeded()
+        }
+    }
+}
+
+// MARK: - Alert 메서드
+extension WriteViewController {
+    // 이미지 상한을 알리는 Alert 표시
+    private func showAlertMaxImageLimitReached() {
+        let alert = UIAlertController(
+            title: "이미지를 추가할 수 없습니다.",
+            message: "하나의 글에 최대 한 개의 이미지만 추가할 수 있습니다.",
+            preferredStyle: .alert
+        )
+        let okAction = UIAlertAction(title: "확인", style: .default) { _ in
+            alert.dismiss(animated: true, completion: nil)
+        }
+        alert.addAction(okAction)
+        DispatchQueue.main.async {
+            self.present(alert, animated: true)
+        }
+    }
+    
+    // 작성 완료 Alert
+    private func showCompletionAlert(completion: @escaping () -> Void) {
+        let alert = UIAlertController(
+            title: "작성 완료",
+            message: "글이 성공적으로 작성되었습니다!",
+            preferredStyle: .alert
+        )
+        let okAction = UIAlertAction(title: "확인", style: .default) { _ in
+            alert.dismiss(animated: true, completion: completion)
+        }
+        alert.addAction(okAction)
+        present(alert, animated: true, completion: nil)
+    }
+    
     // 카메라 권한이 없는 경우 설정 화면으로 이동하는 Alert 표시
     private func showAlertGoToSetting(buttonType: ButtonTapType) {
         let title: String
@@ -270,70 +335,6 @@ final class WriteViewController: UIViewController {
         DispatchQueue.main.async {
             self.present(alertControlelr, animated: true)
         }
-    }
-    
-    // MARK: - Alert 메서드
-    
-    // 이미지 상한을 알리는 Alert 표시
-    private func showAlertMaxImageLimitReached() {
-        let alert = UIAlertController(
-            title: "이미지를 추가할 수 없습니다.",
-            message: "하나의 글에 최대 한 개의 이미지만 추가할 수 있습니다.",
-            preferredStyle: .alert
-        )
-        let okAction = UIAlertAction(title: "확인", style: .default) { _ in
-            alert.dismiss(animated: true, completion: nil)
-        }
-        alert.addAction(okAction)
-        DispatchQueue.main.async {
-            self.present(alert, animated: true)
-        }
-    }
-    
-    // 작성 완료 Alert
-    private func showCompletionAlert(completion: @escaping () -> Void) {
-        let alert = UIAlertController(
-            title: "작성 완료",
-            message: "글이 성공적으로 작성되었습니다!",
-            preferredStyle: .alert
-        )
-        let okAction = UIAlertAction(title: "확인", style: .default) { _ in
-            alert.dismiss(animated: true, completion: completion)
-        }
-        alert.addAction(okAction)
-        present(alert, animated: true, completion: nil)
-    }
-}
-
-// MARK: - 컬렉션뷰 DataSource 설정
-
-extension WriteViewController: UICollectionViewDataSource {
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return writeViewModel.images.count
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ImageCollectionViewCell.identifier, for: indexPath) as? ImageCollectionViewCell else {
-            return UICollectionViewCell()
-        }
-        let image = writeViewModel.images[indexPath.item]
-        cell.configure(with: image)
-        
-        // 삭제 클로저 설정
-        cell.onDelete = { [weak self] in
-            self?.writeViewModel.removeImage(at: indexPath.item)
-            collectionView.reloadData()
-        }
-        return cell
-    }
-}
-
-// MARK: - 텍스트뷰 deleage 설정
-
-extension WriteViewController: UITextViewDelegate {
-    func textViewDidChange(_ textView: UITextView) {
-        // 텍스트가 변경될 때마다 뷰모델에 전달
-        writeViewModel.updateText(textView.text)
     }
 }
 

--- a/Sodam/Sodam/View/Main/WriteView/WriteViewModel.swift
+++ b/Sodam/Sodam/View/Main/WriteView/WriteViewModel.swift
@@ -7,7 +7,6 @@
 
 import UIKit
 import PhotosUI
-import AVFoundation
 
 // 카메라 접근, 사진 선택 로직 처리
 final class WriteViewModel: NSObject {
@@ -28,28 +27,13 @@ final class WriteViewModel: NSObject {
         self.currentHangdamID = currentHangdamID
         super.init()
     }
-    
-    // MARK: - 데이터 접근 메서드
-    
-    // Model의 이미지 데이터를 View에 전달
-    var images: [UIImage] {
-        return writeModel.post.images
-    }
-    // Model의 텍스트 데이터를 View에 전달
-    var text: String {
-        return writeModel.post.content
-    }
-    
-    // MARK: - 데이터 업데이트 메서드
-    
+}
+
+// MARK: - 입력을 모델에 전달
+extension WriteViewModel {
     // 텍스트 업데이트 메서드
     func updateText(_ text: String) {
         writeModel.updateText(text)
-    }
-    
-    // 이미지 제거 메서드
-    func removeImage(at index: Int) {
-        writeModel.removeImage(at: index)
     }
     
     // 작성 완료 이벤트 처리
@@ -66,21 +50,38 @@ final class WriteViewModel: NSObject {
         completion()
     }
     
+    // 뷰에서 이미지 제거
+    func removeImage(at index: Int) {
+        writeModel.removeImage(at: index)
+    }
+    
     // 작성 취소 이벤트 처리
     func cancelPost() {
         saveTemporaryPost()
         isPostSubmitted = false
     }
-    
-    // MARK: - 데이터 변경 관찰
-    
+}
+
+// MARK: - 결과를 뷰에 전달
+extension WriteViewModel {
     // Model의 데이터 변경을 관찰
     func bindPostUpdated(completion: @escaping (Post) -> Void) {
         writeModel.onPostUpdated = completion
     }
     
-    // MARK: - 권한 요청 메서드
+    // Model의 이미지 데이터를 View에 전달
+    var images: [UIImage] {
+        return writeModel.post.images
+    }
     
+    // Model의 텍스트 데이터를 View에 전달
+    var text: String {
+        return writeModel.post.content
+    }
+}
+
+// MARK: - 카메라 관련 설정
+extension WriteViewModel: UINavigationControllerDelegate, UIImagePickerControllerDelegate {
     // 카메라 권한 요청
     func requestCameraAccess(completion: @escaping (Bool) -> Void) {
         let status = AVCaptureDevice.authorizationStatus(for: .video)
@@ -101,6 +102,31 @@ final class WriteViewModel: NSObject {
         }
     }
     
+    // 카메라 컨트롤러 생성
+    func createCameraPicker() -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.sourceType = .camera
+        picker.delegate = self
+        return picker
+    }
+    
+    // 카메라로 찍은 이미지 선택이 완료되었을 때 호출되는 메서드
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+        // 찍은 이미지 가져오기
+        guard let image = info[.originalImage] as? UIImage else {
+            // 이미지가 유효하지 않은 경우 이미지 선택창 닫기
+            picker.dismiss(animated: true)
+            return
+        }
+        // 이미지 추가
+        self.writeModel.addImage(image)
+        // 피커 닫기
+        picker.dismiss(animated: true)
+    }
+}
+
+// MARK: - 이미지 관련 설정
+extension WriteViewModel: PHPickerViewControllerDelegate {
     // 사진 라이브러리 권한 요청
     func requestPhotoLibraryAccess(completion: @escaping (Bool) -> Void) {
         let status = PHPhotoLibrary.authorizationStatus()
@@ -121,16 +147,6 @@ final class WriteViewModel: NSObject {
         }
     }
     
-    // MARK: - 컨트롤러 생성 메서드
-    
-    // 카메라 컨트롤러 생성
-    func createCameraPicker() -> UIImagePickerController {
-        let picker = UIImagePickerController()
-        picker.sourceType = .camera
-        picker.delegate = self
-        return picker
-    }
-    
     // 사진 선택 컨트롤러 생성
     func createPhotoPicker() -> PHPickerViewController {
         var configuration = PHPickerConfiguration()
@@ -141,9 +157,32 @@ final class WriteViewModel: NSObject {
         picker.delegate = self
         return picker
     }
+    
+    // 사진 선택이 완료되었을 때 호출되는 메서드
+    func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+        // 피커 닫기
+        defer {
+            picker.dismiss(animated: true)
+        }
+        
+        // 선택된 결과가 없거나 이미지를 로드할 수 없는 경우 종료
+        guard let provider = results.first?.itemProvider, provider.canLoadObject(ofClass: UIImage.self) else {
+            return
+        }
+        
+        // 이미지 로드
+        provider.loadObject(ofClass: UIImage.self) { [weak self] image, error in
+            if let image = image as? UIImage {
+                DispatchQueue.main.async {
+                    // 이미지 추가
+                    self?.writeModel.addImage(image)
+                }
+            }
+        }
+    }
 }
 
-// MARK: - 이미지 임시저장, 불러오기 메서드
+// MARK: - 이미지 경로 생성 및 저장
 extension WriteViewModel {
     // 이미지 경로 생성 및 파일매니저에 저장하기 위한 메서드
     private func saveImages(_ images: [UIImage]) -> [String] {
@@ -185,51 +224,5 @@ extension WriteViewModel {
                 writeModel.addImage(result)
             }
         }
-    }
-}
-
-
-// MARK: - PHPickerViewController(이미지 선택할 때 사용) 설정
-
-extension WriteViewModel: PHPickerViewControllerDelegate {
-    // 사진 선택이 완료되었을 때 호출되는 메서드
-    func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
-        // 피커 닫기
-        defer {
-            picker.dismiss(animated: true)
-        }
-        
-        // 선택된 결과가 없거나 이미지를 로드할 수 없는 경우 종료
-        guard let provider = results.first?.itemProvider, provider.canLoadObject(ofClass: UIImage.self) else {
-            return
-        }
-        
-        // 이미지 로드
-        provider.loadObject(ofClass: UIImage.self) { [weak self] image, error in
-            if let image = image as? UIImage {
-                DispatchQueue.main.async {
-                    // 이미지 추가
-                    self?.writeModel.addImage(image)
-                }
-            }
-        }
-    }
-}
-
-// MARK: - ImagePickerController(카메라 동작할 때 사용) 설정
-
-extension WriteViewModel: UINavigationControllerDelegate, UIImagePickerControllerDelegate {
-    // 카메라로 찍은 이미지 선택이 완료되었을 때 호출되는 메서드
-    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
-        // 찍은 이미지 가져오기
-        guard let image = info[.originalImage] as? UIImage else {
-            // 이미지가 유효하지 않은 경우 이미지 선택창 닫기
-            picker.dismiss(animated: true)
-            return
-        }
-        // 이미지 추가
-        self.writeModel.addImage(image)
-        // 피커 닫기
-        picker.dismiss(animated: true)
     }
 }


### PR DESCRIPTION
## 1. 요약 
- 레이아웃 수정 전에 코드 먼저 정리 했습니다. 코드 정리는 [Style]로, 레이아웃 수정은 [Modify]로 커밋 했습니다.
- 텍스트뷰 크기를 동적으로 조절하게 하여 레이아웃이 겹치지 않도록 하였습니다.
- 사진을 담을 CollectionView에 사진이 없을 때는 안보이도록 숨김처리 하고, 그만큼 텍스트뷰 크기를 늘어나도록 했습니다.

## 2. 스크린샷 
<img src="https://github.com/user-attachments/assets/73c5c9c5-0b6e-474c-8d4b-a1620ccd39a1" width="40%" height="40%">

- 파란 테두리는 글 작성을 위한 textView 입니다.

- 초록색 테두리는 사진이 담기는 collectionVIew 입니다.

- 빨간색 테두리는 버튼들을 담은 UIView 입니다.

- 테두리는 UI 크기 확인을 편하게 하기 위해 추가한 부분으로 실제 코드에는 지우고 커밋 하였습니다!

## 3. 공유사항
### 코드 수정
- 기존 작성뷰 코드들이 생각나는 대로 작성해둔 면이 있어서, 기능별로 모아두느라 코드 정리를 한 번 했습니다.

- 코드 정리하느라 수정 사항이 많은데, 레이아웃 변경에 대한 코드리뷰는 [Modify] 커밋을 보며 리뷰 해주시면 편할 것 같습니다.

### 레이아웃 변경
- 기존에는 텍스트뷰의 상단과 높이 제약 조건 값을 지정해 크기를 고정시켰는데, 높이 값을 지정하지 않고 하단을 collectionVIew 혹은 containerView의 상단과 맞추어 조절되도록 하였습니다.

- collectionView는 사진을 띄우는 역할을 하였는데, 사진이 없을 때도 공간을 차지하여, 글을 입력하려고 이 부분을 터치하면 아무 동작도 하지않는 경우가 생길 수 있었습니다. 사진이 없을 땐 collectionView를 숨김 처리하여 textView 크기를 최대한 늘렸습니다.

- 하단 버튼 간격이 키보드에 딱 붙어있던 걸 10만큼 띄우도록 일단 조정해두었는데, 각자 실제 기기에 테스트해보고 의견 조율이 필요할 것 같습니다.

- 하단 버튼들이 지금 안전영역으로부터 60만큼 떨어지도록 되어 있는데 다소 어중간하게 띄워져 있는 것 같아서 이 부분도 논의가 필요해 보입니다.