### PR TITLE
[Modify] 최근에 추가한 행복이 리스트 맨 위에 보이도록 처리

### DIFF
--- a/Sodam/Sodam/Model/Manager/CoreDataManager.swift
+++ b/Sodam/Sodam/Model/Manager/CoreDataManager.swift
@@ -128,9 +128,23 @@ final class CoreDataManager {
     }
     
     /// 행담이가 갖고 있는 행복한 기억들 호출
-    func getHappinesses(of hangdamID: NSManagedObjectID) -> [HappinessEntity]? {
-        guard let hangdam = searchHangdam(with: hangdamID) else { return nil }
-        return hangdam.happinesses?.array as? [HappinessEntity]
+    func getHappinesses(of hangdamID: NSManagedObjectID) -> [HappinessEntity] {
+        guard let hangdam = searchHangdam(with: hangdamID) else { return [] }
+        
+        /// 특정 행담이의 행복들 fetch
+        let fetchRequest = NSFetchRequest<HappinessEntity>(entityName: CDKey.happinessEntity.rawValue)
+        fetchRequest.predicate = NSPredicate(format: "hangdam == %@", hangdam)
+        
+        /// 행복을 날짜 내림차순으로 정렬
+        let sortDescriptor = NSSortDescriptor(key: CDKey.date.rawValue, ascending: false)
+        fetchRequest.sortDescriptors = [sortDescriptor]
+        
+        do {
+            return try context.fetch(fetchRequest)
+        } catch {
+            print(DataError.fetchRequestFailed.localizedDescription)
+            return []
+        }
     }
     
     /// 행복한 기억 단일 삭제
@@ -165,4 +179,5 @@ fileprivate enum CDKey: String {
     case container = "SodamContainer"
     case hangdamEntity = "HangdamEntity"
     case happinessEntity = "HappinessEntity"
+    case date
 }

--- a/Sodam/Sodam/Model/Repository/HappinessRepository.swift
+++ b/Sodam/Sodam/Model/Repository/HappinessRepository.swift
@@ -61,14 +61,9 @@ final class HappinessRepository {
     }
     
     /// 행담이가 가진 기억들 호출
-    func getHappinesses(of hangdamID: String) -> [HappinessDTO]? {
-        guard let id = IDConverter.toNSManagedObjectID(from: hangdamID, in: coreDataManager.context)
-        else {
-            print(DataError.convertIDFailed.localizedDescription)
-            return nil
-        }
-        
-        return coreDataManager.getHappinesses(of: id)?.compactMap { $0.toDTO }
+    func getHappinesses(of hangdamID: String) -> [HappinessDTO] {
+        guard let id = IDConverter.toNSManagedObjectID(from: hangdamID, in: coreDataManager.context) else { return [] }
+        return coreDataManager.getHappinesses(of: id).compactMap { $0.toDTO }
     }
     
     /// 기억 삭제

--- a/Sodam/Sodam/View/List/HappinessList/HappinessListView.swift
+++ b/Sodam/Sodam/View/List/HappinessList/HappinessListView.swift
@@ -36,10 +36,9 @@ struct HappinessListView: View {
                         .foregroundStyle(Color.textAccent)
                         .padding(.vertical, 8)
                     
-                    if let happinessList = $viewModel.happinessList.wrappedValue,
-                       !happinessList.isEmpty {
+                    if $viewModel.happinessList.wrappedValue.count > 0 {
                         List {
-                            ForEach(happinessList, id: \.self) { happiness in
+                            ForEach(viewModel.happinessList, id: \.self) { happiness in
                                 HappinessCell(happiness: happiness, happinessRepository: viewModel.getHappinessRepository(), isCanDelete: viewModel.hangdam.endDate == nil ? false : true, image: viewModel.getThumnail(from: happiness.imagePaths.first ?? ""))
                             }
                             .listRowSeparator(.hidden)

--- a/Sodam/Sodam/View/List/HappinessList/HappinessListViewModel.swift
+++ b/Sodam/Sodam/View/List/HappinessList/HappinessListViewModel.swift
@@ -11,7 +11,7 @@ import UIKit
 
 final class HappinessListViewModel: ObservableObject {
     @Published var hangdam: HangdamDTO
-    @Published var happinessList: [HappinessDTO]?
+    @Published var happinessList: [HappinessDTO]
     
     private let happinessRepository: HappinessRepository
     


### PR DESCRIPTION
## 1. 요약
`Core Data`의 `NSPredicate`를 사용한 필터링과 `NSSortDescriptor`를 사용한 정렬을 통해 행복 리스트 정렬 변경 적용
## 2. 스크린샷
![Simulator Screenshot - iPhone 16 Pro - 2025-02-10 at 16 17 41](https://github.com/user-attachments/assets/e94afd49-c249-4d35-bc4e-a83ae0144442)
> 최근에 추가한 행복이 맨 위에 있는 모습
## 3. 공유사항
행복 배열을 옵셔널로 반환했던 메소드들을 `some` case를 반환하도록 수정하고, 예외 상황에서는 빈 값 `[]`을 반환하도록 처리했습니다.