### PR TITLE
[Refactor] LocalNotificationManager 리팩토링, ToastManager 추가

### DIFF
--- a/Sodam/Sodam/Delegate/AppDelegate.swift
+++ b/Sodam/Sodam/Delegate/AppDelegate.swift
@@ -6,135 +6,20 @@
 //
 
 import UIKit
-import UserNotifications
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        let center = UNUserNotificationCenter.current()
-        center.delegate = self
         
-        // 초기 설정 체크 추가
-        checkInitialSetup()
         return true
     }
 
     // MARK: UISceneSession Lifecycle
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-        // Called when a new scene session is being created.
-        // Use this method to select a configuration to create the new scene with.
+        
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
 
-    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-        // Called when the user discards a scene session.
-        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
-        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
-    }
-}
-
-// MARK: - UNUserNotificationCenterDelegate Setting Method
-
-extension AppDelegate: UNUserNotificationCenterDelegate {
-    // Foreground 상태인 경우(앱 실행중인상태) 알림이 오면 해당 메서드 호출
-    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-        print("🔔 Foreground에서 알림 수신: \(notification.request.identifier)") // 로그 추가
-        // 알림 수신 시 뱃지 수를 1씩 증가
-        let currentBadgeCount = UIApplication.shared.applicationIconBadgeNumber
-        UIApplication.shared.applicationIconBadgeNumber = currentBadgeCount + 1
-        
-        completionHandler([.banner, .badge, .sound, .list])
-    }
-    
-    // Background에서 알림 클릭 시 처리사용자가 알림을 탭했을때 해당 메서드 호출
-    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-        completionHandler()  // 응답 처리가 완료되었음을 시스템에 알림
-    }
-}
-
-// MARK: - Private Methods
-
-private extension AppDelegate {
-    // 초기 설정 체크 추가
-    func checkInitialSetup() {
-        let center = UNUserNotificationCenter.current()
-        center.getNotificationSettings { settings in
-            DispatchQueue.main.async { // UI 변경은 반드시 메인 스레드에서 실행
-                switch settings.authorizationStatus {
-                case .notDetermined:
-                    // 권한 요청 (사용자가 한 번도 응답하지 않은 상태)
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { // 1초 후 실행
-                        self.requestNotificationAuthorization()
-                    }
-                case .denied:
-                    // 권한 허용 거부된 경우 → UserDefaultsManager로 중복 표시 방지
-                    if !UserDefaultsManager.shared.getNotificaionAuthorizationStatus() {
-                        self.showToast(message: "알림 권한이 거부되었습니다.")
-                        UserDefaultsManager.shared.saveNotificaionAuthorizationStatus(true) // 최초 한 번만 저장
-                    }
-                case .authorized, .provisional, .ephemeral:
-                    // 초기 설정이 완료 여부
-                    if !UserDefaultsManager.shared.isNotificationSetupComplete() {
-                        self.setDefaultNotificationTime()
-                        UserDefaultsManager.shared.markNotificationSetupAsComplete()
-                    }
-                    UserDefaultsManager.shared.saveNotificaionAuthorizationStatus(true)
-                @unknown default:
-                    break
-                }
-            }
-        }
-    }
-    
-    // 앱 첫 진입시 디폴트 시간
-    func setDefaultNotificationTime() {
-        let calendar = Calendar.current
-        let defaultTime = calendar.date(bySettingHour: 21, minute: 0, second: 0, of: Date())!
-        UserDefaultsManager.shared.saveNotificationTime(defaultTime)
-        
-        // 로컬 알림 예약
-        LocalNotificationManager.shared.setReservedNotification(defaultTime)
-    }
-    
-    // 앱 첫 진입시 권한 허용 여부에 따른 토스트 알림
-    func requestNotificationAuthorization() {
-        let center = UNUserNotificationCenter.current()
-        let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]  // 필요한 알림 권한을 설정
-        
-        center.requestAuthorization(options: authOptions) { success, error in
-            DispatchQueue.main.async { // UI 변경은 반드시 메인 스레드에서 실행
-                if let error = error {
-                    print("알림 권한 요청 중 에러 발생: \(error.localizedDescription)")
-                    return
-                }
-                
-                if success {
-                    self.showToast(message: "알림 시간 설정이 가능합니다.")
-                    // 최초 설정이 완료되지 않았을 경우 기본 시간 설정
-                    if !UserDefaultsManager.shared.isNotificationSetupComplete() {
-                        self.setDefaultNotificationTime()
-                        UserDefaultsManager.shared.markNotificationSetupAsComplete()
-                    }
-                    UserDefaultsManager.shared.saveNotificaionAuthorizationStatus(true)
-                } else {
-                    print("알림 권한이 거부되었습니다.")
-                    // 1초 후에 토스트 메시지 띄우기
-                    self.showToast(message: "알림 권한이 거부되었습니다.")
-                    UserDefaultsManager.shared.saveNotificaionAuthorizationStatus(true)
-                }
-            }
-        }
-    }
-    
-    // 안전하게 토스트 메시지를 표시하는 함수
-    func showToast(message: String) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-            // 현재 최상위 윈도우의 rootViewController의 view에서 토스트 표시(화면전환될때도 토스트 유지)
-            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-               let keyWindow = windowScene.windows.first(where: { $0.isKeyWindow }) {
-                keyWindow.rootViewController?.view.showToast(message: message)
-            }
-        }
-    }
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {}
 }

--- a/Sodam/Sodam/Delegate/SceneDelegate.swift
+++ b/Sodam/Sodam/Delegate/SceneDelegate.swift
@@ -52,9 +52,4 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             overlayView.removeFromSuperview() // 오버레이 제거
         })
     }
-    
-    func sceneDidBecomeActive(_ scene: UIScene) {
-        print("✅ 앱이 활성화됨 - 뱃지 초기화")
-        UIApplication.shared.applicationIconBadgeNumber = 0
-    }
 }

--- a/Sodam/Sodam/Model/Manager/AlertManager.swift
+++ b/Sodam/Sodam/Model/Manager/AlertManager.swift
@@ -48,18 +48,19 @@ final class AlertManager {
         
         let confirmAction = UIAlertAction(title: "확인", style: .default) { _ in
             guard let name = alertController.textFields?.first?.text, !name.isEmpty else {
-                viewController.view.showToast(message: "이름을 입력해주세요.")
+                ToastManager.shared.showToastMessage(message: "이름을 입력해주세요.")
                 return
             }
             
             // 글자 수 확인
             if name.count > 4 {
-                viewController.view.showToast(message: "최대 글자수를 초과했습니다.")
+                ToastManager.shared.showToastMessage(message: "최대 글자수를 초과했습니다.")
+
                 return
             }
             
             if containsForbiddenWord(name) {
-                viewController.view.showToast(message: "적절하지 않은 이름입니다.")
+                ToastManager.shared.showToastMessage(message: "적절하지 않은 이름입니다.")
                 return
             }
             

--- a/Sodam/Sodam/Model/Manager/LocalNotificationManager.swift
+++ b/Sodam/Sodam/Model/Manager/LocalNotificationManager.swift
@@ -8,35 +8,151 @@
 import UserNotifications
 import UIKit
 
-final class LocalNotificationManager {
+final class LocalNotificationManager: NSObject {
     static let shared = LocalNotificationManager()
     
-    private init() {}
+    private override init() {}
+    
+    // 초기 설정 체크 추가
+    func checkInitialSetup() {
+        let center = UNUserNotificationCenter.current()
+        center.getNotificationSettings { settings in
+            // UI 변경은 반드시 메인 스레드에서 실행
+            DispatchQueue.main.async {
+                switch settings.authorizationStatus {
+                
+                // 권한 상태가 아직 결정되지 않은 경우
+                case .notDetermined:
+                    self.requestNotificationAuthorization { granted in
+                        if granted {
+                            self.setupDefaultNotificationIfNeeded()
+                        }
+                    }
+                
+                // 사용자가 알림 권한을 거부한 경우
+                case .denied:
+                    self.showDeniedToastOnce()
+                    
+                // 권한이 허용된 상태 (.authorized), 임시 권한 (.provisional), 임시적인 권한 (.ephemeral)인 경우
+                case .authorized, .provisional, .ephemeral:
+                    self.setupDefaultNotificationIfNeeded()
+                    
+                @unknown default:
+                    break
+                }
+            }
+        }
+    }
+    
+    // 사용자에게 알림 권한을 요청하는 메서드 (최초 1회만 실행)
+    func requestNotificationAuthorization(completion: @escaping (Bool) -> Void) {
+        // 이미 권한이 설정되어 있는 경우 요청하지 않음
+        guard !UserDefaultsManager.shared.getNotificaionAuthorizationStatus() else {
+            completion(true)
+            return
+        }
+        
+        let center = UNUserNotificationCenter.current()
+        let options: UNAuthorizationOptions = [.alert, .badge, .sound]
+        
+        center.requestAuthorization(options: options) { granted, error in
+            DispatchQueue.main.async {
+                if granted {
+                    UserDefaultsManager.shared.saveNotificaionAuthorizationStatus(true)
+                    completion(true)
+                } else {
+                    self.showDeniedToastOnce()
+                    completion(false)
+                }
+            }
+        }
+    }
     
     /// 특정 시점에 알람 설정(매일, 사용자가 선택한 시간)
     /// - Parameters:
     ///   - time: 사용자가 설정한 알림 시간
     func setReservedNotification(_ time: Date) {
-        let content = UNMutableNotificationContent()
-        content.title = "Sodam"  // Push Notification에 표시할 제목
-        content.body = "소소한 행복을 적어 행담이를 키워주세요."  // Push Notification에 표시할 본문
-        content.sound = .default
-        content.badge = NSNumber(value: UIApplication.shared.applicationIconBadgeNumber + 1) // 기존 뱃지 숫자에서 1씩 증가
+        let identifier = "SelectedTimeNotification"
         
-        let calendar = Calendar.current
-        let components = calendar.dateComponents([.hour, .minute], from: time)
-        
-        let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: true) // ✅ 매일 설정한 시간에 울리게 설정
-        
-        // identifier: 실행 취소, 알림 구분 등에 사용되는 식별자
-        let request = UNNotificationRequest(identifier: "SelectedTimeNotification", content: content, trigger: trigger)
-
-        UNUserNotificationCenter.current().add(request) { error in
-            if let error = error {
-                print("❌ 알림 등록 실패: \(error.localizedDescription)")
-            } else {
-                print("✅ 알림 등록 성공! 예약 시간: \(components.hour ?? 0):\(components.minute ?? 0)")
+        UNUserNotificationCenter.current().getPendingNotificationRequests { requests in
+            
+            let content = UNMutableNotificationContent()
+            content.title = "Sodam"
+            content.body = "소소한 행복을 적어 행담이를 키워주세요."
+            content.sound = .default
+            
+            // 뱃지 숫자 증가를 메인 스레드에서 실행
+            DispatchQueue.main.async {
+                content.badge = NSNumber(value: UIApplication.shared.applicationIconBadgeNumber + 1)
+                print("Content Badge: \(content.badge ?? 0)") // Badge 값 출력
+            }
+            
+            let calendar = Calendar.current
+            let components = calendar.dateComponents([.hour, .minute], from: time)
+            let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: true)
+            
+            let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
+            
+            UNUserNotificationCenter.current().add(request) { error in
+                DispatchQueue.main.async {
+                    if error != nil {
+                        ToastManager.shared.showToastMessage(message: "알림 등록 실패")
+                    } else {
+                        let isAlreadyScheduled = requests.contains { $0.identifier == identifier }
+                        guard !isAlreadyScheduled else {
+                            ToastManager.shared.showToastMessage(message: "알림 시간이\(components.hour ?? 0):\(String(format: "%02d", components.minute ?? 0))로 변경되었습니다.")
+                            return
+                        }
+                        ToastManager.shared.showToastMessage(message: "기본 알림 시간9시로 설정되었습니다.")
+                    }
+                }
             }
         }
+    }
+}
+
+// MARK: - Private Methods
+
+private extension LocalNotificationManager {
+    // 앱 첫 실행 시 기본 알림 설정 (최초 1회만 실행)
+    func setupDefaultNotificationIfNeeded() {
+        // 기본 알림이 이미 설정되었는지 확인
+        guard !UserDefaultsManager.shared.isNotificationSetupComplete() else { return }
+        
+        let calendar = Calendar.current
+        let defaultTime = calendar.date(bySettingHour: 21, minute: 0, second: 0, of: Date())!
+        UserDefaultsManager.shared.saveNotificationTime(defaultTime)
+        
+        // 기본 알림 예약 설정
+        self.setReservedNotification(defaultTime)
+        
+        // 기본 알림 설정 완료 상태 저장
+        UserDefaultsManager.shared.markNotificationSetupAsComplete()
+    }
+    
+    // 알림 권한이 거부된 경우, 사용자에게 한 번만 알림을 제공하는 메서드
+    func showDeniedToastOnce() {
+        guard !UserDefaultsManager.shared.getNotificaionAuthorizationStatus() else { return }
+        
+        ToastManager.shared.showToastMessage(message: "알림 권한이 거부되었습니다.")
+        UserDefaultsManager.shared.saveNotificaionAuthorizationStatus(true) // 사용자가 권한을 거부했을 때 "한 번만" 안내 메시지를 띄우도록 하는 목적(false면 메시지가 계속 뜨게 됨)
+    }
+}
+
+// MARK: - UNUserNotificationCenterDelegate Setting Method
+
+extension LocalNotificationManager: UNUserNotificationCenterDelegate {
+    // Foreground 상태인 경우(앱 실행중인상태) 알림이 오면 해당 메서드 호출
+    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        // 알림 수신 시 뱃지 수를 1씩 증가
+        let currentBadgeCount = UIApplication.shared.applicationIconBadgeNumber
+        UIApplication.shared.applicationIconBadgeNumber = currentBadgeCount + 1
+        
+        completionHandler([.banner, .badge, .sound, .list])
+    }
+    
+    // Background에서 알림 클릭 시 처리사용자가 알림을 탭했을때 해당 메서드 호출
+    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        completionHandler()  // 응답 처리가 완료되었음을 시스템에 알림
     }
 }

--- a/Sodam/Sodam/Model/Manager/LocalNotificationManager.swift
+++ b/Sodam/Sodam/Model/Manager/LocalNotificationManager.swift
@@ -11,41 +11,46 @@ import UIKit
 final class LocalNotificationManager: NSObject {
     static let shared = LocalNotificationManager()
     
-    private override init() {}
+    private override init() {
+        super.init()
+        UNUserNotificationCenter.current().delegate = self
+    }
     
-    // 초기 설정 체크 추가
+    // 초기 설정 체크
     func checkInitialSetup() {
         let center = UNUserNotificationCenter.current()
-        center.getNotificationSettings { settings in
-            // UI 변경은 반드시 메인 스레드에서 실행
-            DispatchQueue.main.async {
-                switch settings.authorizationStatus {
-                
-                // 권한 상태가 아직 결정되지 않은 경우
-                case .notDetermined:
-                    self.requestNotificationAuthorization { granted in
-                        if granted {
-                            self.setupDefaultNotificationIfNeeded()
-                        }
-                    }
-                
-                // 사용자가 알림 권한을 거부한 경우
-                case .denied:
-                    self.showDeniedToastOnce()
-                    
-                // 권한이 허용된 상태 (.authorized), 임시 권한 (.provisional), 임시적인 권한 (.ephemeral)인 경우
-                case .authorized, .provisional, .ephemeral:
-                    self.setupDefaultNotificationIfNeeded()
-                    
-                @unknown default:
-                    break
-                }
-            }
+        // 알림 권한 설정을 비동기로 확인(center.getNotificationSettings)하고 그 결과에 따라 처리
+        center.getNotificationSettings { [weak self] settings in
+            self?.handleNotificationAuthorizationStatus(settings.authorizationStatus)
         }
     }
     
-    // 사용자에게 알림 권한을 요청하는 메서드 (최초 1회만 실행)
-    func requestNotificationAuthorization(completion: @escaping (Bool) -> Void) {
+    // 알림 권한 상태 처리
+    private func handleNotificationAuthorizationStatus(_ status: UNAuthorizationStatus) {
+        switch status {
+        // 권한이 아직 결정되지 않은 경우 권한 요청
+        case .notDetermined:
+            requestNotificationAuthorization { [weak self] granted in
+                if granted {
+                    // 권한이 허가되면 기본 알림 설정
+                    self?.setupDefaultNotificationIfNeeded()
+                }
+            }
+            
+        // 권한이 거부된 경우 안내 메시지 표시
+        case .denied:
+            showDeniedToastOnce()
+            
+        // 권한이 이미 허가되었거나 임시 허가된 경우 기본 알림 설정
+        case .authorized, .provisional, .ephemeral:
+            setupDefaultNotificationIfNeeded()
+        @unknown default:
+            break
+        }
+    }
+    
+    // 알림 권한 요청 (최초 1회만 실행)
+    private func requestNotificationAuthorization(completion: @escaping (Bool) -> Void) {
         // 이미 권한이 설정되어 있는 경우 요청하지 않음
         guard !UserDefaultsManager.shared.getNotificaionAuthorizationStatus() else {
             completion(true)
@@ -55,104 +60,136 @@ final class LocalNotificationManager: NSObject {
         let center = UNUserNotificationCenter.current()
         let options: UNAuthorizationOptions = [.alert, .badge, .sound]
         
-        center.requestAuthorization(options: options) { granted, error in
-            DispatchQueue.main.async {
-                if granted {
-                    UserDefaultsManager.shared.saveNotificaionAuthorizationStatus(true)
-                    completion(true)
+        center.requestAuthorization(options: options) { [weak self] granted, error in
+            if granted {
+                // 권한이 허가여부를 UserDefaults에 저장(true가 허용)
+                UserDefaultsManager.shared.saveNotificaionAuthorizationStatus(true)
+                completion(true)
+            } else {
+                // 권한이 거부된 경우 안내 메시지 표시(false가 거부)
+                self?.showDeniedToastOnce()
+                completion(false)
+            }
+        }
+    }
+    
+    // 알림 시간 설정 (사용자가 설정한 시간)
+    func setReservedNotification(_ time: Date) {
+        let identifier = "SelectedTimeNotification"
+        
+        // 현재 대기 중인 알림 요청을 가져와서 새로운 알림 예약
+        UNUserNotificationCenter.current().getPendingNotificationRequests { [weak self] requests in
+            self?.scheduleNotification(time: time, identifier: identifier, existingRequests: requests)
+        }
+    }
+    
+    // 알림 예약
+    private func scheduleNotification(time: Date, identifier: String, existingRequests: [UNNotificationRequest]) {
+        createNotificationContent { content in
+            // 알림을 트리거할 시간 설정
+            let trigger = self.createNotificationTrigger(for: time)
+            let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
+            
+            // 알림을 UNUserNotificationCenter에 추가
+            UNUserNotificationCenter.current().add(request) { [weak self] error in
+                if let error = error {
+                    // 알림 등록 실패 시 에러 메시지 표시
+                    DispatchQueue.main.async {
+                        ToastManager.shared.showToastMessage(message: "알림 등록 실패: \(error.localizedDescription)")
+                    }
                 } else {
-                    self.showDeniedToastOnce()
-                    completion(false)
+                    // 알림이 성공적으로 등록된 후 후속 처리
+                    self?.handleNotificationScheduling(identifier: identifier, time: time, existingRequests: existingRequests)
                 }
             }
         }
     }
     
-    /// 특정 시점에 알람 설정(매일, 사용자가 선택한 시간)
-    /// - Parameters:
-    ///   - time: 사용자가 설정한 알림 시간
-    func setReservedNotification(_ time: Date) {
-        let identifier = "SelectedTimeNotification"
+    // 알림 내용 생성
+    private func createNotificationContent(completion: @escaping (UNMutableNotificationContent) -> Void) {
+        let content = UNMutableNotificationContent()
+        content.title = "Sodam"
+        content.body = "소소한 행복을 적어 행담이를 키워주세요."
+        content.sound = .default
         
-        UNUserNotificationCenter.current().getPendingNotificationRequests { requests in
-            
-            let content = UNMutableNotificationContent()
-            content.title = "Sodam"
-            content.body = "소소한 행복을 적어 행담이를 키워주세요."
-            content.sound = .default
-            
-            // 뱃지 숫자 증가를 메인 스레드에서 실행
-            DispatchQueue.main.async {
-                content.badge = NSNumber(value: UIApplication.shared.applicationIconBadgeNumber + 1)
-                print("Content Badge: \(content.badge ?? 0)") // Badge 값 출력
-            }
-            
-            let calendar = Calendar.current
-            let components = calendar.dateComponents([.hour, .minute], from: time)
-            let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: true)
-            
-            let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
-            
-            UNUserNotificationCenter.current().add(request) { error in
-                DispatchQueue.main.async {
-                    if error != nil {
-                        ToastManager.shared.showToastMessage(message: "알림 등록 실패")
-                    } else {
-                        let isAlreadyScheduled = requests.contains { $0.identifier == identifier }
-                        guard !isAlreadyScheduled else {
-                            ToastManager.shared.showToastMessage(message: "알림 시간이\(components.hour ?? 0):\(String(format: "%02d", components.minute ?? 0))로 변경되었습니다.")
-                            return
-                        }
-                        ToastManager.shared.showToastMessage(message: "기본 알림 시간9시로 설정되었습니다.")
-                    }
-                }
-            }
+        DispatchQueue.main.async {
+            // 메인 스레드에서 badge 값 가져오기
+            let currentBadgeNumber = UIApplication.shared.applicationIconBadgeNumber
+            content.badge = NSNumber(value: currentBadgeNumber + 1)
         }
+        
+        completion(content) // 비동기로 content를 반환
+    }
+    
+    // MARK: - 알림 트리거 생성
+    
+    // 알림 트리거를 생성하는 함수 (특정 시간에 알림이 발생하도록 설정)
+    private func createNotificationTrigger(for time: Date) -> UNCalendarNotificationTrigger {
+        let calendar = Calendar.current
+        let components = calendar.dateComponents([.hour, .minute], from: time)
+        return UNCalendarNotificationTrigger(dateMatching: components, repeats: true)
+    }
+    
+    // MARK: - 알림 예약 후 처리
+    
+    private func handleNotificationScheduling(identifier: String, time: Date, existingRequests: [UNNotificationRequest]) {
+        // 이미 동일한 알림이 예약되어 있는지 확인
+        let isAlreadyScheduled = existingRequests.contains { $0.identifier == identifier }
+        DispatchQueue.main.async {
+            // 알림이 새로 예약되었거나 시간이 변경되었음을 사용자에게 알림
+            let message = isAlreadyScheduled ? "알림 시간이 \(self.timeFormatted(time))로 변경되었습니다." : "기본 알림 시간 \(self.timeFormatted(time))로 설정되었습니다."
+            ToastManager.shared.showToastMessage(message: message)
+        }
+    }
+    
+    // MARK: - 시간을 "HH:mm" 형식으로 변환
+    
+    private func timeFormatted(_ time: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        return formatter.string(from: time)
     }
 }
 
 // MARK: - Private Methods
 
 private extension LocalNotificationManager {
-    // 앱 첫 실행 시 기본 알림 설정 (최초 1회만 실행)
+    // 기본 알림 설정 (최초 1회만 실행)
     func setupDefaultNotificationIfNeeded() {
-        // 기본 알림이 이미 설정되었는지 확인
         guard !UserDefaultsManager.shared.isNotificationSetupComplete() else { return }
         
         let calendar = Calendar.current
         let defaultTime = calendar.date(bySettingHour: 21, minute: 0, second: 0, of: Date())!
         UserDefaultsManager.shared.saveNotificationTime(defaultTime)
         
-        // 기본 알림 예약 설정
-        self.setReservedNotification(defaultTime)
-        
-        // 기본 알림 설정 완료 상태 저장
-        UserDefaultsManager.shared.markNotificationSetupAsComplete()
+        setReservedNotification(defaultTime)  // 기본 알림 설정을 예약
+        UserDefaultsManager.shared.markNotificationSetupAsComplete()  // 기본 알림 설정 완료 상태를 저장
     }
     
-    // 알림 권한이 거부된 경우, 사용자에게 한 번만 알림을 제공하는 메서드
+    // 알림 권한이 거부된 경우 사용자에게 한 번만 안내 메시지 제공
     func showDeniedToastOnce() {
+        // 권한이 거부된 상태를 UserDefaults에 저장
         guard !UserDefaultsManager.shared.getNotificaionAuthorizationStatus() else { return }
+        UserDefaultsManager.shared.saveNotificaionAuthorizationStatus(true)
         
-        ToastManager.shared.showToastMessage(message: "알림 권한이 거부되었습니다.")
-        UserDefaultsManager.shared.saveNotificaionAuthorizationStatus(true) // 사용자가 권한을 거부했을 때 "한 번만" 안내 메시지를 띄우도록 하는 목적(false면 메시지가 계속 뜨게 됨)
+        // 알림 권한 거부 메시지 표시
+        DispatchQueue.main.async {
+            ToastManager.shared.showToastMessage(message: "알림 권한이 거부되었습니다.")
+        }
     }
 }
 
-// MARK: - UNUserNotificationCenterDelegate Setting Method
+// MARK: - UNUserNotificationCenterDelegate
 
 extension LocalNotificationManager: UNUserNotificationCenterDelegate {
-    // Foreground 상태인 경우(앱 실행중인상태) 알림이 오면 해당 메서드 호출
+    // Foreground 상태에서 알림을 수신할 때 호출
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-        // 알림 수신 시 뱃지 수를 1씩 증가
-        let currentBadgeCount = UIApplication.shared.applicationIconBadgeNumber
-        UIApplication.shared.applicationIconBadgeNumber = currentBadgeCount + 1
-        
+        UIApplication.shared.applicationIconBadgeNumber += 1  // 배지 번호를 증가시켜 앱 아이콘에 표시
         completionHandler([.banner, .badge, .sound, .list])
     }
     
-    // Background에서 알림 클릭 시 처리사용자가 알림을 탭했을때 해당 메서드 호출
+    // Background에서 알림을 클릭했을 때 호출
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-        completionHandler()  // 응답 처리가 완료되었음을 시스템에 알림
+        completionHandler() // 응답 처리 완료
     }
 }

--- a/Sodam/Sodam/Model/Manager/ToastManager.swift
+++ b/Sodam/Sodam/Model/Manager/ToastManager.swift
@@ -1,0 +1,76 @@
+//
+//  ToastManager.swift
+//  Sodam
+//
+//  Created by 박시연 on 2/10/25.
+//
+
+import UIKit
+
+final class ToastManager {
+    // 싱글턴 인스턴스
+    static let shared = ToastManager()
+    
+    private init() {} // 외부에서 인스턴스를 생성할 수 없도록 init은 private
+    
+    // 특정 뷰에서 토스트 표시
+    func showToastMessage(message: String, duration: TimeInterval = 2.0) {
+        let scenes = UIApplication.shared.connectedScenes
+        guard let windowScene = scenes.first as? UIWindowScene,
+              let window = windowScene.windows.first else {
+            return
+        }
+        
+        // 토스트 표시할 Label 생성
+        let label = UILabel()
+        label.textColor = UIColor.white
+        label.textAlignment = .center
+        label.font = .mapoGoldenPier(16)
+        label.text = message // 표시할 메세지 설정
+        label.alpha = 0.0 // 초기 투명도 (완전 투명)
+        label.layer.cornerRadius = 10
+        label.clipsToBounds = true
+        label.numberOfLines = 0
+        label.lineBreakMode = .byWordWrapping // 줄 바꿈
+        
+        // 내부 패딩을 위해 UIView 감싸기
+        let toastContainer = UIView()
+        toastContainer.alpha = 0.0
+        toastContainer.backgroundColor = UIColor.black.withAlphaComponent(0.3)
+        toastContainer.layer.cornerRadius = 10
+        toastContainer.clipsToBounds = true
+
+        // 토스트 뷰에 추가
+        window.addSubview(toastContainer)
+        toastContainer.addSubview(label)
+
+        // 레이아웃 수정
+        toastContainer.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalTo(window.snp.bottom).inset(window.bounds.height * 0.25) // 화면 하단에서 일정 거리 떨어짐
+            $0.leading.greaterThanOrEqualTo(toastContainer.snp.leading).inset(12)
+            $0.trailing.lessThanOrEqualTo(toastContainer.snp.trailing).inset(12)
+        }
+
+        // label이 자동으로 늘어나도록 설정
+        label.snp.makeConstraints {
+            $0.top.bottom.equalToSuperview().inset(10) // 내부 여백 추가
+            $0.leading.trailing.equalToSuperview().inset(12) // 좌우 여백 추가
+        }
+        
+        // 애니메이션으로 토스트 메시지 표시
+        UIView.animate(withDuration: 0.5, delay: 0.0, options: .curveEaseIn, animations: {
+            label.alpha = 1.0 // 0.5초 동안 투명도 1.0으로 변경되면서 서서히 나타남
+            toastContainer.alpha = 1.0
+        }, completion: { _ in
+            
+            // 토스트 메세지가 일정 시간동안 표시된 후 사라지는 애니메이션
+            UIView.animate(withDuration: 0.5, delay: duration, options: .curveEaseOut, animations: {
+                label.alpha = 0.0 // 0.5초 동안 투명도를 0.0으로 서서히 사라짐
+                toastContainer.alpha = 0.0
+            }, completion: { _ in
+                label.removeFromSuperview() // 애니메이션 끝나면 Label을 뷰에서 제거함
+            })
+        })
+    }
+}

--- a/Sodam/Sodam/Model/Manager/UserDefaultsManager.swift
+++ b/Sodam/Sodam/Model/Manager/UserDefaultsManager.swift
@@ -25,58 +25,71 @@ final class UserDefaultsManager {
     
     // MARK: - UserDefaults에 저장
     
+    // 알림 시간을 UserDefaults에 저장
     func saveNotificationTime(_ time: Date) {
         userDefaults.set(time, forKey: Keys.notificationTime)
     }
     
+    // 알림 토글 상태 (ON/OFF)를 UserDefaults에 저장
     func saveNotificationToggleState(_ isOn: Bool) {
         userDefaults.set(isOn, forKey: Keys.notificationToggleState)
     }
     
+    // 작성된 내용(content)을 UserDefaults에 저장
     func saveContent(_ content: String) {
         userDefaults.set(content, forKey: Keys.content)
     }
     
+    // 작성된 이미지 경로(imagePath)를 UserDefaults에 저장
     func saveImagePath(_ imagePath: [String]) {
         userDefaults.set(imagePath, forKey: Keys.imagePath)
     }
     
+    // 알림 권한 상태 (허용/거부)를 UserDefaults에 저장
     func saveNotificaionAuthorizationStatus(_ isAuthorized: Bool) {
         userDefaults.set(isAuthorized, forKey: Keys.notificationAuthorizationStatus)
     }
     
+    // 알림 초기 설정 완료 여부를 확인 (알림 설정이 처음 완료되었는지 여부)
     func isNotificationSetupComplete() -> Bool {
         return userDefaults.bool(forKey: Keys.notificationInitialSetupComplete)
     }
 
     // MARK: - UserDefaults에 저장된 값 얻어오기
     
+    // 저장된 알림 시간을 가져옴
     func getNotificationTime() -> Date? {
         userDefaults.object(forKey: Keys.notificationTime) as? Date
     }
     
+    // 알림 토글 상태 (ON/OFF)를 가져옴
     func getNotificationToggleState() -> Bool {
         userDefaults.bool(forKey: Keys.notificationToggleState)
     }
     
+    // 작성된 내용을 가져옴
     func getContent() -> String? {
         userDefaults.string(forKey: Keys.content)
     }
     
+    // 저장된 이미지 경로 목록을 가져옴
     func getImagePath() -> [String]? {
         userDefaults.stringArray(forKey: Keys.imagePath)
     }
     
+    // 임시 저장된 콘텐츠와 이미지 경로 삭제
     func deleteTemporaryPost() {
         print("[WriteView] 임시저장 됐던 content와 imagePath 삭제")
         userDefaults.removeObject(forKey: Keys.content)
         userDefaults.removeObject(forKey: Keys.imagePath)
     }
     
+    // 저장된 알림 권한 상태를 가져옴
     func getNotificaionAuthorizationStatus() -> Bool {
         return userDefaults.bool(forKey: Keys.notificationAuthorizationStatus)
     }
     
+    // 알림 초기 설정을 완료 표시 (첫 설정 후 완료 상태로 변경)
     func markNotificationSetupAsComplete() {
         userDefaults.set(true, forKey: Keys.notificationInitialSetupComplete)
     }

--- a/Sodam/Sodam/View/Main/MainView/MainViewController.swift
+++ b/Sodam/Sodam/View/Main/MainView/MainViewController.swift
@@ -47,6 +47,7 @@ final class MainViewController: UIViewController {
     override func viewWillAppear (_ animated: Bool) {
         viewModel.reloadHangdam() // ViewModel에서 행담이 데이터를 갱신
         updateButtonState()       // 화면이 다시 나타날 때 버튼 상태 갱신
+        LocalNotificationManager.shared.checkInitialSetup()  // 앱 첫 진입시 알림 권한 팝업 설정
     }
     
     // MARK: - bind view model for update view

--- a/Sodam/Sodam/View/Setting/SettingsViewController.swift
+++ b/Sodam/Sodam/View/Setting/SettingsViewController.swift
@@ -9,14 +9,16 @@ import UIKit
 
 final class SettingsViewController: UIViewController {
     private let settingViewModel: SettingViewModel
-
     private let settingView = SettingView()
 
+    // MARK: - Initializer
+    
     init(settingViewModel: SettingViewModel) {
         self.settingViewModel = settingViewModel
         super.init(nibName: nil, bundle: nil)
     }
     
+    // 스토리보드 등에서 사용되지 않으므로, 해당 초기화는 구현하지 않음
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -29,12 +31,13 @@ final class SettingsViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .viewBackground
         setupTableView()
-        setupScheduledNotification()
-        
-        // 앱이 포그라운드로 돌아올 때마다 알림 권한 확인
+        // 사용자 설정 화면에 진입할 때 뱃지 초기화
+        UIApplication.shared.applicationIconBadgeNumber = 0
+        // 앱이 포그라운드로 돌아올 때마다 알림 권한 상태를 재확인하여 UI(스위치 상태)를 업데이트
         NotificationCenter.default.addObserver(self, selector: #selector(checkNotificationPermissionAndUpdateSwitch), name: UIApplication.willEnterForegroundNotification, object: nil)
     }
     
+    // 뷰 컨트롤러가 소멸되기 전에 옵저버를 제거
     deinit {
         NotificationCenter.default.removeObserver(self)
     }
@@ -42,7 +45,7 @@ final class SettingsViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        // 알림 권한 상태를 다시 체크하여 스위치 상태를 업데이트
+        // 알림 권한 상태를 체크하여 스위치의 초기 상태를 업데이트
         checkNotificationPermissionAndUpdateSwitch()
     }
 }
@@ -58,23 +61,17 @@ private extension SettingsViewController {
         settingView.tableView.register(SettingTableViewCell.self, forCellReuseIdentifier: SettingTableViewCell.reuseIdentifier)
     }
     
-    func setupScheduledNotification() {
-        // UserDefaults에서 알림 상태 체크
-        if settingViewModel.isToggleOn {
-            if let savedTime = settingViewModel.getNotificationTime() {
-                print("savedTime \(savedTime)")
-                settingViewModel.setReservedNotificaion(savedTime)
-            }
-        }
-        // 알림 토글 상태에 따라 UI 업데이트
-        settingView.tableView.reloadSections(IndexSet(integer: 0), with: .automatic)
-    }
-    
+    /// 현재 알림 권한 상태를 확인한 후, 해당 상태에 따라 스위치와 알림 시간을 업데이트
+    ///
+    /// - 설명:
+    ///   1. `UNUserNotificationCenter`의 설정을 가져와 사용자가 알림을 허용했는지 확인
+    ///   2. 허용된 경우 스위치를 ON 상태로 만들고, 저장된 알림 시간이 없으면 기본 시간(21:00)으로 설정
+    ///   3. 거부된 경우 스위치를 OFF 상태로 유지하고, 상태를 저장
     @objc func checkNotificationPermissionAndUpdateSwitch() {
         UNUserNotificationCenter.current().getNotificationSettings { settings in
             DispatchQueue.main.async {
-                _ = !self.settingViewModel.isToggleOn // 이전 상태 확인
-                let isAuthorizedNow = settings.authorizationStatus == .authorized
+                //_ = !self.settingViewModel.isToggleOn
+                let isAuthorizedNow = settings.authorizationStatus == .authorized  // 현재 알림 권한이 허용된 상태인지 확인
                 
                 if isAuthorizedNow {
                     // 사용자가 설정에서 알림을 허용했을 경우
@@ -88,12 +85,12 @@ private extension SettingsViewController {
                         self.settingViewModel.setReservedNotificaion(defaultTime)
                     }
                 } else {
-                    // 여전히 거부 상태면 스위치를 OFF로 유지
+                    // 알림 권한이 거부된 경우 스위치를 OFF로 설정
                     self.settingViewModel.isToggleOn = false
                     self.settingViewModel.saveIsToggleNotification(false)
                 }
                 
-                // UI 업데이트
+                // 변경된 상태를 반영하기 위해 테이블뷰의 첫 번째 섹션을 다시 로드
                 self.settingView.tableView.reloadSections(IndexSet(integer: 0), with: .automatic)
             }
         }
@@ -192,7 +189,6 @@ extension SettingsViewController: UITableViewDataSource, UITableViewDelegate {
         switch sectionType {
         case .develop:
             if indexPath.row == 0 {
-                // TODO: - 앱 배포전 링크로 배포전 이동 안되는게 맞음
                 settingViewModel.openURL("https://apps.apple.com/us/app/sodam/id6741320265")
             }
         default:
@@ -200,33 +196,35 @@ extension SettingsViewController: UITableViewDataSource, UITableViewDelegate {
         }
     }
     
+    // 알림 스위치의 상태가 변경되었을 때 호출되는 액션
     @objc func didToggleSwitch(_ sender: UISwitch) {
-        // 현재 알림 권한 상태 확인
+        // 알림 권한 상태를 비동기로 확인하여, 권한이 없는 경우 경고창을 띄우고 스위치를 OFF로 변경
+        // TODO: UserDefatulsManager로 변경 필요
         UNUserNotificationCenter.current().getNotificationSettings { settings in
             DispatchQueue.main.async {
                 if settings.authorizationStatus != .authorized {
-                    // 권한이 허용되지 않은 경우
+                    // 알림 권한이 없는 경우 스위치를 OFF 상태로 되돌리고, 권한 요청 안내 알럿 띄움
                     sender.isOn = false // 토글을 다시 OFF 상태로 변경
                     self.showNotificationPermissionAlert()
                 } else {
-                    // 권한이 허용된 경우 알림 울리도록 설정
+                    // 권한이 허용된 경우, 토글 상태에 따라 알림 예약/해제 로직을 수행
                     self.handleNotificationToggle(isOn: sender.isOn)
                 }
             }
         }
     }
     
-    // 사용자가 선택한 알림 시간 UserDefaultsManager에 저장
+    // 사용자가 DatePicker를 통해 알림 시간을 선택했을 때 호출되는 액션
     @objc func userScheduleNotification(_ sender: UIDatePicker) {
+        //선택한 시간을 뷰모델에 저장하고, 알림 스위치가 켜진 경우 알림 예약을 업데이트
         settingViewModel.saveNotificationTime(sender.date)
-        print("sender.date11 \(sender.date)")
 
         if settingViewModel.isToggleOn {
             settingViewModel.setReservedNotificaion(sender.date)
         }
     }
     
-    // 알림 권한이 없을 때 경고창 띄우기
+    // 알림 권한이 없는 경우 사용자에게 알림 권한 설정을 요청하는 알럿띄움 함수
     private func showNotificationPermissionAlert() {
         let alertController = UIAlertController(
             title: "알림 권한 필요",
@@ -252,24 +250,29 @@ extension SettingsViewController: UITableViewDataSource, UITableViewDelegate {
         }
     }
     
-    // 권한이 허용된 경우 알림 울리도록 설정 (토글이 켜졌을 때 실행)
+    // 알림 스위치가 On/Off시 실행되는 메서드
     private func handleNotificationToggle(isOn: Bool) {
+        // 뷰모델의 상태를 업데이트하고 UserDefaults에 저장
         settingViewModel.isToggleOn = isOn
         settingViewModel.saveIsToggleNotification(isOn)
         
         if isOn {
+            // 알림 스위치가 켜진 경우, 저장된 알림 시간이 있으면 해당 시간으로 알림 예약을 진행
             if let savedTime = settingViewModel.getNotificationTime() {
                 settingViewModel.setReservedNotificaion(savedTime)
             } else {
-                // 저장된 시간이 없는 경우 현재 시간을 기본값으로 저장
+                // 저장된 시간이 없는 경우 현재 시간을 기본값으로 사용하여 알림 예약
+                // TODO: 현재시간이 아닌 디폴트 9시 재확인
                 let currentDate = Date()
                 settingViewModel.saveNotificationTime(currentDate)
                 settingViewModel.setReservedNotificaion(currentDate)
             }
         } else {
+            // 알림 스위치가 꺼진 경우, 미리 예약된 알림 요청을 제거
             UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: ["SelectedTimeNotification"])
         }
         
+        // 알림 스위치 상태 변경에 따른 UI 갱신을 위해 첫 번째 섹션을 다시 로드
         settingView.tableView.reloadSections(IndexSet(integer: 0), with: .automatic)
     }
 }

--- a/Sodam/Sodam/View/Setting/SettingsViewController.swift
+++ b/Sodam/Sodam/View/Setting/SettingsViewController.swift
@@ -31,8 +31,7 @@ final class SettingsViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .viewBackground
         setupTableView()
-        // 사용자 설정 화면에 진입할 때 뱃지 초기화
-        UIApplication.shared.applicationIconBadgeNumber = 0
+        
         // 앱이 포그라운드로 돌아올 때마다 알림 권한 상태를 재확인하여 UI(스위치 상태)를 업데이트
         NotificationCenter.default.addObserver(self, selector: #selector(checkNotificationPermissionAndUpdateSwitch), name: UIApplication.willEnterForegroundNotification, object: nil)
     }
@@ -45,8 +44,9 @@ final class SettingsViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        // 알림 권한 상태를 체크하여 스위치의 초기 상태를 업데이트
-        checkNotificationPermissionAndUpdateSwitch()
+        UIApplication.shared.applicationIconBadgeNumber = 0  // 사용자 설정 화면에 진입할 때 뱃지 초기화
+        checkNotificationPermissionAndUpdateSwitch()  // 알림 권한 상태를 체크하여 스위치의 초기 상태를 업데이트
+
     }
 }
 


### PR DESCRIPTION
## 1. 요약 
1. LocalNotificationManager 싱글턴으로 리팩토링
2. ToastManager 싱글턴 추가

## 2. 스크린샷 

## 3. 공유사항
아래와 같은 버그는 추가적으로 수정예정입니다

- [ ] 0시 넘겨서 행복 남겼을 때 알림 처리
- [ ] 알림 1개 이상 쌓여도 그대로 뱃지 1인 버그 수정
- [ ] 설정에서 알림 끈 다음에 다른 화면 갔다가 다시 설정 가면 켜져 있는 현상 수정
- [ ] 사용자에게 버그 제보, 피드백 받는 구글폼 링크로 이동하는 셀 추가
