### PR TITLE
[Refactor] DTO mapper

### DIFF
--- a/Sodam/Sodam/Model/DTO/DTOMapper.swift
+++ b/Sodam/Sodam/Model/DTO/DTOMapper.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import CoreData
 
 struct HangdamMapper {
     func toDTO(from entity: HangdamEntity) -> HangdamDTO {
@@ -33,5 +34,20 @@ struct HappinessMapper {
             imagePaths: imagePaths,
             hangdamID: IDConverter.toStringID(from: entity.hangdam?.objectID)
         )
+    }
+    
+    func toEntity(from dto: HappinessDTO, context: NSManagedObjectContext) -> Result<HappinessEntity, DataError> {
+        guard let data = try? NSKeyedArchiver.archivedData(withRootObject: dto.imagePaths, requiringSecureCoding: true)
+        else {
+            print(DataError.convertImagePathsFailed.localizedDescription)
+            return .failure(DataError.convertImagePathsFailed)
+        }
+        
+        let entity = HappinessEntity(context: context)
+        entity.content = dto.content
+        entity.date = dto.date
+        entity.imagePaths = data
+        
+        return .success(entity)
     }
 }

--- a/Sodam/Sodam/Model/DTO/DTOMapper.swift
+++ b/Sodam/Sodam/Model/DTO/DTOMapper.swift
@@ -1,0 +1,37 @@
+//
+//  DTOMapper.swift
+//  Sodam
+//
+//  Created by EMILY on 11/02/2025.
+//
+
+import Foundation
+
+struct HangdamMapper {
+    func toDTO(from entity: HangdamEntity) -> HangdamDTO {
+        return HangdamDTO(
+            id: IDConverter.toStringID(from: entity.objectID),
+            name: entity.name,
+            happinessCount: entity.happinesses?.count ?? 0,
+            startDate: entity.startDate?.formatForHangdam,
+            endDate: entity.endDate?.formatForHangdam
+        )
+    }
+}
+
+struct HappinessMapper {
+    func toDTO(from entity: HappinessEntity) -> HappinessDTO? {
+        guard let content = entity.content,
+              let date = entity.date,
+              let imagePaths = entity.imagePaths?.toStringArray
+        else { return nil }
+        
+        return HappinessDTO(
+            id: IDConverter.toStringID(from: entity.objectID),
+            content: content,
+            date: date,
+            imagePaths: imagePaths,
+            hangdamID: IDConverter.toStringID(from: entity.hangdam?.objectID)
+        )
+    }
+}

--- a/Sodam/Sodam/Model/DTO/HangdamDTO.swift
+++ b/Sodam/Sodam/Model/DTO/HangdamDTO.swift
@@ -39,15 +39,3 @@ struct HangdamDTO {
         }
     }
 }
-
-extension HangdamEntity {
-    var toDTO: HangdamDTO {
-        return HangdamDTO(
-            id: IDConverter.toStringID(from: self.objectID),
-            name: self.name,
-            happinessCount: self.happinesses?.count ?? 0,
-            startDate: self.startDate?.formatForHangdam,
-            endDate: self.endDate?.formatForHangdam
-        )
-    }
-}

--- a/Sodam/Sodam/Model/DTO/HappinessDTO.swift
+++ b/Sodam/Sodam/Model/DTO/HappinessDTO.swift
@@ -18,22 +18,3 @@ struct HappinessDTO: Hashable {
         return date.formatForHappiness
     }
 }
-
-extension HappinessEntity {
-    var toDTO: HappinessDTO? {
-        guard let content = self.content,
-              let date = self.date,
-              let imagePaths = self.imagePaths?.toStringArray
-        else {
-            return nil
-        }
-        
-        return HappinessDTO(
-            id: IDConverter.toStringID(from: self.objectID),
-            content: content,
-            date: date,
-            imagePaths: imagePaths,
-            hangdamID: IDConverter.toStringID(from: self.hangdam?.objectID)
-        )
-    }
-}

--- a/Sodam/Sodam/Model/Manager/CoreDataManager.swift
+++ b/Sodam/Sodam/Model/Manager/CoreDataManager.swift
@@ -103,22 +103,21 @@ final class CoreDataManager {
     
     /// 행복한 기억 생성 : 행담이 id 받아 행담이에 추가
     func createHappiness(_ dto: HappinessDTO, to hangdamID: NSManagedObjectID) {
-        guard let data = try? NSKeyedArchiver.archivedData(withRootObject: dto.imagePaths, requiringSecureCoding: true)
-        else {
-            print(DataError.convertImagePathsFailed.localizedDescription)
+        /// dto를 entity로 매핑
+        let mapper = HappinessMapper()
+        let mapResult = mapper.toEntity(from: dto, context: context)
+        
+        switch mapResult {
+        case .failure:
+            /// toEntity 메소드 내부에 DataError를 출력하고 있어 더 처리 하지 않음 - 추후에 error handling 필요
             return
+        case .success(let entity):
+            /// 행담이에 추가
+            appendHappiness(entity, to: hangdamID)
+            
+            print("[CoreData] 행복 생성 완료")
+            saveContext()
         }
-        
-        let entity = HappinessEntity(context: context)
-        entity.content = dto.content
-        entity.date = dto.date
-        entity.imagePaths = data
-        
-        /// 행담이에 추가
-        appendHappiness(entity, to: hangdamID)
-        
-        print("[CoreData] 행복 생성 완료")
-        saveContext()
     }
     
     /// 행복한 기억을 행담이에 추가하는 메소드 - 내부 호출

--- a/Sodam/Sodam/Model/Repository/HangdamRepository.swift
+++ b/Sodam/Sodam/Model/Repository/HangdamRepository.swift
@@ -10,9 +10,14 @@ import Foundation
 /// CoreDataManager와 ViewModel 사이에서 행담이 데이터 처리를 맡는 객체
 final class HangdamRepository {
     private let coreDataManager: CoreDataManager
+    private let dtoMapper: HangdamMapper
     
-    init(coreDataManager: CoreDataManager = CoreDataManager.shared) {
+    init(
+        coreDataManager: CoreDataManager = CoreDataManager.shared,
+        dtoMapper: HangdamMapper = .init()
+    ) {
         self.coreDataManager = coreDataManager
+        self.dtoMapper = dtoMapper
     }
     
     /// 현재 키우는 행담이 불러오기
@@ -25,19 +30,19 @@ final class HangdamRepository {
             return createNewHangdam()
         }
         
-        return currentHangdam.toDTO
+        return dtoMapper.toDTO(from: currentHangdam)
     }
     
     /// 보관된 행담이들 불러오기 : 현재 키우는 행담이 제외하고 다 큰 행담이들
     func getSavedHangdams() -> [HangdamDTO] {
         guard coreDataManager.fetchHangdams().count > 1 else { return [] }
         
-        return coreDataManager.fetchHangdams().dropLast().compactMap { $0.toDTO }
+        return coreDataManager.fetchHangdams().dropLast().compactMap { dtoMapper.toDTO(from: $0) }
     }
     
     /// 새로운 행담이 생성
     private func createNewHangdam() -> HangdamDTO {
-        return coreDataManager.createHangdam().toDTO
+        return dtoMapper.toDTO(from: coreDataManager.createHangdam())
     }
     
     /// 행담이 이름 짓기

--- a/Sodam/Sodam/Model/Repository/HappinessRepository.swift
+++ b/Sodam/Sodam/Model/Repository/HappinessRepository.swift
@@ -13,10 +13,16 @@ import CoreData
 final class HappinessRepository {
     private let coreDataManager: CoreDataManager
     private let imageManager: ImageManager
+    private let dtoMapper: HappinessMapper
     
-    init(coreDataManager: CoreDataManager = CoreDataManager.shared, imageManager: ImageManager = ImageManager()) {
+    init(
+        coreDataManager: CoreDataManager = CoreDataManager.shared,
+        imageManager: ImageManager = ImageManager(),
+        dtoMapper: HappinessMapper = .init()
+    ) {
         self.coreDataManager = coreDataManager
         self.imageManager = imageManager
+        self.dtoMapper = dtoMapper
     }
     
     /// 행복한 기억 생성
@@ -55,7 +61,7 @@ final class HappinessRepository {
     /// 행담이가 가진 기억들 호출
     func getHappinesses(of hangdamID: String) -> [HappinessDTO] {
         guard let id = IDConverter.toNSManagedObjectID(from: hangdamID, in: coreDataManager.context) else { return [] }
-        return coreDataManager.getHappinesses(of: id).compactMap { $0.toDTO }
+        return coreDataManager.getHappinesses(of: id).compactMap { dtoMapper.toDTO(from: $0) }
     }
     
     /// 기억 삭제


### PR DESCRIPTION
## 1. 요약
행담이와 행복의 dto - entity 간 mapping을 담당하는 객체 정의
## 2. 스크린샷
## 3. 공유사항
Entity를 extension하여 `toDTO`라는 계산 프로퍼티를 통해 편하게 Entity → DTO 변환을 한다고 생각했던 코드가 (내가)편하기만 한 코드일 뿐 DTO로 하여금 Entity에 의존하게 된다는 사실을 간과했습니다. 튜터님의 프로젝트 피드백 내용을 반영하여 매핑을 담당하는 구조체를 따로 정의하여 repository에서 mapper를 통해 entity를 dto로 변환하도록 리팩토링 했습니다.
+ 행복 dto - entity 변환을 `CoreDataManager`에서 직접 하던 것을 mapper에게 역할 분담했습니다.
(행담이는 dto - entity 방향 생성이 이루어지지 않기 때문에 toEntity를 구현하지 않았습니다.)