### PR TITLE
[Modify] 줄 간격 및 버튼 색깔 수정

### DIFF
--- a/Sodam/Sodam/View/Main/WriteView/ImageCollectionViewCell.swift
+++ b/Sodam/Sodam/View/Main/WriteView/ImageCollectionViewCell.swift
@@ -21,11 +21,11 @@ final class ImageCollectionViewCell: UICollectionViewCell {
     // 휴지통 버튼
     private let deleteButton: UIButton = {
         let button = UIButton()
-        button.tintColor = .black
+        button.tintColor = .red
         button.layer.cornerRadius = 8
         var config = UIButton.Configuration.plain()
         config.image = UIImage(systemName: "trash")
-        config.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(pointSize: 12) // 이미지 크기 설정
+        config.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(pointSize: 10) // 이미지 크기 설정
         button.configuration = config
         return button
     }()
@@ -56,7 +56,7 @@ final class ImageCollectionViewCell: UICollectionViewCell {
         
         blurView.snp.makeConstraints { make in
             make.top.trailing.equalToSuperview().inset(4)
-            make.width.height.equalTo(24)
+            make.width.height.equalTo(20)
         }
         
         deleteButton.snp.makeConstraints { make in

--- a/Sodam/Sodam/View/Main/WriteView/WriteView.swift
+++ b/Sodam/Sodam/View/Main/WriteView/WriteView.swift
@@ -28,7 +28,6 @@ class WriteView: UIView {
     // 글 작성 텍스트뷰
     private let textView: UITextView = {
         let textView: UITextView = UITextView()
-        textView.font = .sejongGeulggot(16)
         textView.textColor = .darkGray
         textView.backgroundColor = .viewBackground
         return textView
@@ -38,7 +37,7 @@ class WriteView: UIView {
     private let placeholderLabel: UILabel = {
         let label = UILabel()
         label.text = "행복을 작성해주세요"
-        label.font = UIFont.systemFont(ofSize: 16)
+        label.font = .sejongGeulggot(16)
         label.textColor = .lightGray
         return label
     }()
@@ -60,7 +59,7 @@ class WriteView: UIView {
     // 카메라 버튼
     private let cameraButton: UIButton = {
         let button: UIButton = UIButton()
-        button.tintColor = .gray
+        button.tintColor = .textAccent
         var config = UIButton.Configuration.plain()
         config.image = UIImage(systemName: "camera")
         config.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(pointSize: 20) // 이미지 크기 설정
@@ -71,7 +70,7 @@ class WriteView: UIView {
     // 사진 선택 버튼
     private let imageButton: UIButton = {
         let button: UIButton = UIButton()
-        button.tintColor = .gray
+        button.tintColor = .textAccent
         var config = UIButton.Configuration.plain()
         config.image = UIImage(systemName: "photo.on.rectangle")
         config.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(pointSize: 20)
@@ -82,7 +81,7 @@ class WriteView: UIView {
     // 작성 완료 버튼
     private let submitButton: UIButton = {
         let button: UIButton = UIButton()
-        button.tintColor = .gray
+        button.tintColor = .textAccent
         var config = UIButton.Configuration.plain()
         config.image = UIImage(systemName: "checkmark")
         config.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(pointSize: 20)
@@ -93,7 +92,7 @@ class WriteView: UIView {
     // dismiss 버튼
     private let dismisslButton: UIButton = {
         let button: UIButton = UIButton()
-        button.tintColor = .gray
+        button.tintColor = .textAccent
         var config = UIButton.Configuration.plain()
         config.image = UIImage(systemName: "xmark")
         config.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(pointSize: 20)
@@ -158,7 +157,7 @@ extension WriteView {
         containerView.snp.makeConstraints { make in
             make.leading.trailing.equalTo(safeAreaLayoutGuide).inset(20)
             make.height.equalTo(safeAreaLayoutGuide.snp.height).multipliedBy(0.05)
-            containerBottomConstraint = make.bottom.equalTo(safeAreaLayoutGuide.snp.bottom).inset(60).constraint
+            containerBottomConstraint = make.bottom.equalTo(safeAreaLayoutGuide.snp.bottom).inset(20).constraint
         }
         
         collectionView.snp.makeConstraints { make in
@@ -252,6 +251,26 @@ extension WriteView {
         placeholderLabel.isHidden = !textView.text.isEmpty
     }
     
+    // 텍스트뷰 줄 간격 설정 메서드 추가
+    private func updateTextViewAttributes() {
+        let font = UIFont.sejongGeulggot(16)
+        let lineHeight = font.lineHeight // 폰트는 기본 줄 높이
+        let swiftUILineSpacing: CGFloat = 10 // SwiftUI에서 사용한 lineSpacing 값
+        
+        // UIKit의 lineSpacing 계산 (SwiftUI와 일치시키기)
+        let adjustedLineSpacing = swiftUILineSpacing - (lineHeight - font.pointSize)
+        
+        let parapraphStyle = NSMutableParagraphStyle()
+        parapraphStyle.lineSpacing = adjustedLineSpacing
+        
+        let attributes: [NSAttributedString.Key: Any] = [
+            .paragraphStyle: parapraphStyle,
+            .font: font
+        ]
+        
+        textView.attributedText = NSAttributedString(string: textView.text, attributes: attributes)
+    }
+    
     // 텍스트뷰 delegate 설정 메서드
     func setTextViewDeleaget(delegate: UITextViewDelegate) {
         textView.delegate = delegate
@@ -266,6 +285,7 @@ extension WriteView {
     func setTextViewText(_ text: String) {
         textView.text = text
         updatePlaceholderVisibility() // 텍스트 변경 시 Placeholder 업데이트
+        updateTextViewAttributes() // 텍스트 변경 시 스타일 적용
     }
 }
 

--- a/Sodam/Sodam/View/Main/WriteView/WriteView.swift
+++ b/Sodam/Sodam/View/Main/WriteView/WriteView.swift
@@ -59,7 +59,7 @@ class WriteView: UIView {
     // 카메라 버튼
     private let cameraButton: UIButton = {
         let button: UIButton = UIButton()
-        button.tintColor = .textAccent
+        button.tintColor = .darkGray
         var config = UIButton.Configuration.plain()
         config.image = UIImage(systemName: "camera")
         config.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(pointSize: 20) // 이미지 크기 설정
@@ -70,7 +70,7 @@ class WriteView: UIView {
     // 사진 선택 버튼
     private let imageButton: UIButton = {
         let button: UIButton = UIButton()
-        button.tintColor = .textAccent
+        button.tintColor = .darkGray
         var config = UIButton.Configuration.plain()
         config.image = UIImage(systemName: "photo.on.rectangle")
         config.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(pointSize: 20)
@@ -81,7 +81,7 @@ class WriteView: UIView {
     // 작성 완료 버튼
     private let submitButton: UIButton = {
         let button: UIButton = UIButton()
-        button.tintColor = .textAccent
+        button.tintColor = .darkGray
         var config = UIButton.Configuration.plain()
         config.image = UIImage(systemName: "checkmark")
         config.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(pointSize: 20)
@@ -92,7 +92,7 @@ class WriteView: UIView {
     // dismiss 버튼
     private let dismisslButton: UIButton = {
         let button: UIButton = UIButton()
-        button.tintColor = .textAccent
+        button.tintColor = .darkGray
         var config = UIButton.Configuration.plain()
         config.image = UIImage(systemName: "xmark")
         config.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(pointSize: 20)

--- a/Sodam/Sodam/View/Main/WriteView/WriteViewController.swift
+++ b/Sodam/Sodam/View/Main/WriteView/WriteViewController.swift
@@ -254,7 +254,7 @@ extension WriteViewController {
         }
         
         // 키보드가 사라지면 컨테이너 뷰의 제약 조건을 원래대로 복원
-        writeView.updateContainerBottomConstraint(inset: 60)
+        writeView.updateContainerBottomConstraint(inset: 20)
         
         UIView.animate(withDuration: animationDuration) {
             self.view.layoutIfNeeded()


### PR DESCRIPTION
## 1. 요약 
- 긴 글 입력했을 때 줄 간격 조절했습니다.
- 버튼 색깔 회색인거랑, 높이가 과하게 위로 올라가 있는 부분이 어색하다고 생각해서 수정했습니다.

## 2. 스크린샷 
<img src="https://github.com/user-attachments/assets/ae78de40-538c-4f3d-9d55-0c813376ac49" width="40%" height="40%">

## 3. 공유사항
- 줄 간격은 swiftUI에서 작성한 linespacing과 같아지도록 수식을 사용했습니다.
- 버튼 색을 gray에서 날짜나 입력한 글자 색과 같은 darkGray로 변경하였습니다
- 이미지 삭제 버튼의 trash 아이콘이 눈에 잘 안띄어서 색깔을 red로 변경했습니다. 기존에는 black이었습니다.
- 버튼 높이 안전영역으로부터 60 띄우도록 했는데, se에서도 그렇고 홈인디케이터 있는 기종에서도 그렇고 과하게 띄워져 있는 것 같아서 20으로 줄였습니다.