### PR TITLE
[Modify] 행복 디테일 뷰 폰트와 줄 간격 적용

### DIFF
--- a/Sodam/Sodam/View/List/HappinessDetail/HappinessDetailView.swift
+++ b/Sodam/Sodam/View/List/HappinessDetail/HappinessDetailView.swift
@@ -29,7 +29,8 @@ struct HappinessDetailView: View {
                     }
                     HStack(alignment: .top) {
                         Text(viewModel.happiness.content)
-                            .font(.maruburiot(type: .regular, size: 16))
+                            .font(.sejongGeulggot(16))
+                            .lineSpacing(10)
                             .foregroundStyle(Color(UIColor.darkGray))
                             .multilineTextAlignment(.leading)
                             .padding(.horizontal, 16)

--- a/Sodam/Sodam/View/List/HappinessList/HappinessCell.swift
+++ b/Sodam/Sodam/View/List/HappinessList/HappinessCell.swift
@@ -36,7 +36,7 @@ struct HappinessCell: View {
                 VStack(alignment: .leading) {
 //                    Text(happiness.content)
                     Text(content)
-                        .font(.mapoGoldenPier(FontSize.body))
+                        .font(.sejongGeulggot(16))
                         .foregroundStyle(.black)
                         .lineLimit(2)
                         .padding(.bottom, 8)


### PR DESCRIPTION
## 1. 요약
업데이트 배포를 위해 진홍님 작업 merge 안되고 그냥 closed 됐던 PR 다시 적용해서 올립니다.
## 2. 스크린샷
| HappinessListView | HappinessDetailView |
| ----- | ----- |
| <img src="https://github.com/user-attachments/assets/fc545828-01e2-4f52-b61e-86b0eb2b6e86" width=430> | <img src="https://github.com/user-attachments/assets/e8cc798d-9c4b-48d5-a515-441aaed63e82" width=430> |
## 3. 공유사항
