### PR TITLE
[Fix] Navigation 쌓였을 때 Tabbar 처리

### DIFF
--- a/Sodam/Sodam/Helper/TabBarHelper.swift
+++ b/Sodam/Sodam/Helper/TabBarHelper.swift
@@ -10,7 +10,22 @@ import UIKit
 import SwiftUI
 
 final class TabBarHelper {
-    func setTabBarVisitility(_ isVisible: Bool) {
+    /// HappinessListView가 기록 탭에서는 탭 바가 보여야하고, 보관 탭에서 네비게이션 stack에 쌓이면 탭 바를 숨겨야 함
+    func setTabBarVisibilityByTab() {
+        withAnimation {
+            guard let tabBarController = getRootTabBarController() else { return }
+            
+            switch tabBarController.selectedIndex {
+            case 2:
+                tabBarController.tabBar.isHidden = true
+            default:
+                tabBarController.tabBar.isHidden = false
+            }
+        }
+    }
+    
+    /// 파라미터의 bool 값에 따라 tabbar를 보이고/숨기는 메소드
+    func setTabBarVisibility(_ isVisible: Bool) {
         withAnimation {
             if let tabBarController = getRootTabBarController() {
                 tabBarController.tabBar.isHidden = !isVisible
@@ -29,6 +44,7 @@ final class TabBarHelper {
     }
 }
 
+/// TabBarHelper의 setTabBarVisibility 메소드를 호출하는 modifier를 만드는 구조체
 struct TabBarVisibilityModifier: ViewModifier {
     let isTabBarVisible: Bool
     var tabBarHelper: TabBarHelper = .init()
@@ -36,13 +52,30 @@ struct TabBarVisibilityModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .onAppear {
-                tabBarHelper.setTabBarVisitility(isTabBarVisible)
+                tabBarHelper.setTabBarVisibility(isTabBarVisible)
             }
     }
 }
 
+/// TabBarHelper의 setTabBarVisibilityByTab 메소드를 호출하는 modifier를 만드는 구조체
+struct TabBarVisibilityForListViewModifier: ViewModifier {
+    var tabBarHelper: TabBarHelper = .init()
+    
+    func body(content: Content) -> some View {
+        content
+            .onAppear {
+                tabBarHelper.setTabBarVisibilityByTab()
+            }
+    }
+}
+
+/// SwiftUI View에서 modifier로 사용할 수 있게 extension에 추가
 extension View {
     func tabBarVisibility(_ isTabBarVisible: Bool) -> some View {
         modifier(TabBarVisibilityModifier(isTabBarVisible: isTabBarVisible))
+    }
+    
+    func tabBarVisibilityByTab() -> some View {
+        modifier(TabBarVisibilityForListViewModifier())
     }
 }

--- a/Sodam/Sodam/Helper/TabBarHelper.swift
+++ b/Sodam/Sodam/Helper/TabBarHelper.swift
@@ -1,0 +1,48 @@
+//
+//  TabBarHelper.swift
+//  Sodam
+//
+//  Created by EMILY on 16/02/2025.
+//
+
+import Foundation
+import UIKit
+import SwiftUI
+
+final class TabBarHelper {
+    func setTabBarVisitility(_ isVisible: Bool) {
+        withAnimation {
+            if let tabBarController = getRootTabBarController() {
+                tabBarController.tabBar.isHidden = !isVisible
+            }
+        }
+    }
+    
+    private func getRootTabBarController() -> UITabBarController? {
+        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let sceneDelegate = scene.delegate as? SceneDelegate,
+              let rootViewController = sceneDelegate.window?.rootViewController else {
+            return nil
+        }
+        
+        return rootViewController as? UITabBarController
+    }
+}
+
+struct TabBarVisibilityModifier: ViewModifier {
+    let isTabBarVisible: Bool
+    var tabBarHelper: TabBarHelper = .init()
+    
+    func body(content: Content) -> some View {
+        content
+            .onAppear {
+                tabBarHelper.setTabBarVisitility(isTabBarVisible)
+            }
+    }
+}
+
+extension View {
+    func tabBarVisibility(_ isTabBarVisible: Bool) -> some View {
+        modifier(TabBarVisibilityModifier(isTabBarVisible: isTabBarVisible))
+    }
+}

--- a/Sodam/Sodam/View/List/HappinessDetail/HappinessDetailView.swift
+++ b/Sodam/Sodam/View/List/HappinessDetail/HappinessDetailView.swift
@@ -15,7 +15,7 @@ struct HappinessDetailView: View {
     @Environment(\.dismiss) private var dismiss
     
     var body: some View {
-        NavigationStack{
+        NavigationStack {
             ScrollView {
                 VStack {
                     if let imagePath = viewModel.happiness.imagePaths.first {
@@ -39,6 +39,7 @@ struct HappinessDetailView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
+            .scrollIndicators(.hidden)
             .frame(maxWidth: .infinity)
             .background(Color.viewBackground)
             .padding()

--- a/Sodam/Sodam/View/List/HappinessDetail/HappinessDetailView.swift
+++ b/Sodam/Sodam/View/List/HappinessDetail/HappinessDetailView.swift
@@ -43,6 +43,7 @@ struct HappinessDetailView: View {
             .frame(maxWidth: .infinity)
             .background(Color.viewBackground)
             .padding()
+            .tabBarVisibility(false)
         }
         .background(Color.viewBackground.ignoresSafeArea())
         .ignoresSafeArea(edges: .bottom)

--- a/Sodam/Sodam/View/List/HappinessDetail/HappinessDetailView.swift
+++ b/Sodam/Sodam/View/List/HappinessDetail/HappinessDetailView.swift
@@ -17,7 +17,7 @@ struct HappinessDetailView: View {
     var body: some View {
         NavigationStack {
             ScrollView {
-                VStack {
+                VStack(spacing: 16) {
                     if let imagePath = viewModel.happiness.imagePaths.first {
                         Image(uiImage: self.viewModel.getImage(from: imagePath))
                             .resizable()
@@ -25,24 +25,21 @@ struct HappinessDetailView: View {
                             .clipShape(.rect(cornerRadius: 15))
                             .padding()
                             .background(RoundedRectangle(cornerRadius: 15).foregroundStyle(Color.cellBackground))
-                            .padding(.bottom)
                     }
-                    HStack(alignment: .top) {
-                        Text(viewModel.happiness.content)
-                            .font(.sejongGeulggot(16))
-                            .lineSpacing(10)
-                            .foregroundStyle(Color(UIColor.darkGray))
-                            .multilineTextAlignment(.leading)
-                            .padding(.horizontal, 16)
-                        
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                    Text(viewModel.happiness.content)
+                        .font(.sejongGeulggot(16))
+                        .lineSpacing(10)
+                        .foregroundStyle(Color(UIColor.darkGray))
+                        .multilineTextAlignment(.leading)
+                        .padding(.horizontal, 8)        // TODO: default랑 비교
+                        .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
             .scrollIndicators(.hidden)
             .frame(maxWidth: .infinity)
             .background(Color.viewBackground)
             .padding()
+            .padding(.bottom, 32)           // TODO: 없는 거랑 비교
             .tabBarVisibility(false)
         }
         .background(Color.viewBackground.ignoresSafeArea())

--- a/Sodam/Sodam/View/List/HappinessDetail/HappinessDetailView.swift
+++ b/Sodam/Sodam/View/List/HappinessDetail/HappinessDetailView.swift
@@ -31,7 +31,7 @@ struct HappinessDetailView: View {
                         .lineSpacing(10)
                         .foregroundStyle(Color(UIColor.darkGray))
                         .multilineTextAlignment(.leading)
-                        .padding(.horizontal, 8)        // TODO: default랑 비교
+                        .padding(.horizontal, 8)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
@@ -39,7 +39,7 @@ struct HappinessDetailView: View {
             .frame(maxWidth: .infinity)
             .background(Color.viewBackground)
             .padding()
-            .padding(.bottom, 32)           // TODO: 없는 거랑 비교
+            .padding(.bottom, 32)
             .tabBarVisibility(false)
         }
         .background(Color.viewBackground.ignoresSafeArea())

--- a/Sodam/Sodam/View/List/HappinessList/HappinessListView.swift
+++ b/Sodam/Sodam/View/List/HappinessList/HappinessListView.swift
@@ -76,6 +76,7 @@ struct HappinessListView: View {
                         }
                     }
                 }
+                .tabBarVisibilityByTab()
             }
             .padding([.top, .horizontal])
             .background(Color.viewBackground)

--- a/Sodam/Sodam/View/List/HappinessList/HappinessListView.swift
+++ b/Sodam/Sodam/View/List/HappinessList/HappinessListView.swift
@@ -97,16 +97,6 @@ struct HappinessListView: View {
             .navigationBarBackButtonHidden(isBackButtonHidden)
         }
     }
-    
-    private func getRootTabBarController() -> UITabBarController? {
-        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-              let sceneDelegate = scene.delegate as? SceneDelegate,
-              let rootViewController = sceneDelegate.window?.rootViewController else {
-            return nil
-        }
-        
-        return rootViewController as? UITabBarController
-    }
 }
 
 enum FontSize {

--- a/Sodam/Sodam/View/Storage/HangdamStorageView.swift
+++ b/Sodam/Sodam/View/Storage/HangdamStorageView.swift
@@ -33,26 +33,10 @@ struct HangdamStorageView: View {
             .padding(.horizontal)
             .background(Color.viewBackground)
             .onAppear {
-                withAnimation {
-                    if let tabBarController = getRootTabBarController() {
-                        tabBarController.tabBar.isHidden = false
-                    }
-                }
                 viewModel.loadHangdams()
             }
         }
         .tint(.textAccent)
-    }
-    
-    // MARK: - Helper method
-    
-    private func getRootTabBarController() -> UITabBarController? {
-        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-              let sceneDelegate = scene.delegate as? SceneDelegate,
-              let rootViewController = sceneDelegate.window?.rootViewController else {
-            return nil
-        }
-        return rootViewController as? UITabBarController
     }
 }
 

--- a/Sodam/Sodam/View/Storage/HangdamStorageView.swift
+++ b/Sodam/Sodam/View/Storage/HangdamStorageView.swift
@@ -32,6 +32,7 @@ struct HangdamStorageView: View {
             }
             .padding(.horizontal)
             .background(Color.viewBackground)
+            .tabBarVisibility(true)
             .onAppear {
                 viewModel.loadHangdams()
             }

--- a/Sodam/Sodam/View/Storage/HangdamStorageView.swift
+++ b/Sodam/Sodam/View/Storage/HangdamStorageView.swift
@@ -37,8 +37,8 @@ struct HangdamStorageView: View {
                     if let tabBarController = getRootTabBarController() {
                         tabBarController.tabBar.isHidden = false
                     }
-                    viewModel.loadHangdams()
                 }
+                viewModel.loadHangdams()
             }
         }
         .tint(.textAccent)


### PR DESCRIPTION
## 1. 요약 
민석님이 발견하신 디테일 뷰에서 스크롤 문제
- 현상 : 스크롤을 맨 밑까지 내렸음에도 불구하고 내용이 끝까지 보이지 않음(스크롤이 다시 위로 튕기는 것처럼 보임)
- 원인 : 탭바가 화면의 맨 밑을 가림
- 해결 방법 : 네비게이션이 쌓였을 때 탭바를 가린다.
## 2. 스크린샷 
![Screenshot 2025-02-16 at 18 36 15](https://github.com/user-attachments/assets/45e1f0d0-1948-4ac2-b249-96f5080be6d7)
> 원인 분석 : 탭바가 화면의 맨 밑을 가리는 현상 발견
<img src="https://github.com/user-attachments/assets/23d3e52f-8b51-4772-a9e1-bd38bdf32dd6" width=450>

> 해결 화면 : 디테일 뷰 진입시 탭바 hide
## 3. 공유사항
- `HappinessListView`가 기록탭과 보관탭에서 재사용되는데, 선택된 탭 상황에 따라 탭바가 보이거나/숨기거나 해야해서 이걸 custom modifier로 처리했습니다.
- 진홍님이 구현하신 `getRootTabBarController()` 메소드를 `TabBarHelper`로 옮겼습니다.