### PR TITLE
[Fix] Storage view rendering bug

### DIFF
--- a/Sodam/Sodam/View/Storage/HangdamStorageView.swift
+++ b/Sodam/Sodam/View/Storage/HangdamStorageView.swift
@@ -30,6 +30,7 @@ struct HangdamStorageView: View {
                     .scrollIndicators(.hidden)
                 }
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
             .padding(.horizontal)
             .background(Color.viewBackground)
             .tabBarVisibility(true)


### PR DESCRIPTION
## 1. 요약 
보관함 뷰에 첫 진입 시 왼쪽 상단에서 뷰가 로드되는 현상 수정했습니다.
해결법은 뷰의 frame을 미리 설정해두어 로드되는 데이터에 따라 frame이 변경되지 않도록 했습니다.
## 2. 스크린샷 
## 3. 공유사항