### PR TITLE
[Fix] Back action gesture bug

### DIFF
--- a/Sodam/Sodam/View/List/HappinessDetail/HappinessDetailView.swift
+++ b/Sodam/Sodam/View/List/HappinessDetail/HappinessDetailView.swift
@@ -45,22 +45,8 @@ struct HappinessDetailView: View {
         .background(Color.viewBackground.ignoresSafeArea())
         .ignoresSafeArea(edges: .bottom)
         .navigationBarTitleDisplayMode(.inline)
-        .navigationBarBackButtonHidden(true)
+        .tint(.textAccent)
         .toolbar {
-            ToolbarItem(placement: .topBarLeading) {
-                Button(action: {
-                    dismiss()
-                }) {
-                    HStack {
-                        Image(systemName: "chevron.left")
-                            .foregroundStyle(Color.textAccent) // 색상 지정 안해주면 파란색으로 나옴
-                        Text("기억들")
-                            .font(.maruburiot(type: .bold, size: 16))
-                            .foregroundStyle(Color.textAccent)
-                    }
-                }
-            }
-            
             ToolbarItem(placement: .principal) {
                 Text(viewModel.content.happinessDate)
                     .font(.maruburiot(type: .bold, size: 20))


### PR DESCRIPTION
## 1. 요약 
Back버튼을 숨기고 "기억들"이라는 이름으로 별개의 버튼을 만드는 과정에서 뒤로가기 제스처가 소실된 버그 수정
Back버튼을 다시 살리고 대신 tint컬러 지정 했습니다.
back버튼 이름은 이전 네비게이션의 타이틀을 따르는데 수정하려고 하니 UIKit과 연결해야 해서 그냥 Back버튼으로 놔두었습니다.
## 2. 스크린샷 
## 3. 공유사항
