### PR TITLE
[Fix] 작성뷰 모달 상태표시줄 안보이던 것 수정

### DIFF
--- a/Sodam/Sodam/View/Main/MainView/MainViewController.swift
+++ b/Sodam/Sodam/View/Main/MainView/MainViewController.swift
@@ -108,6 +108,7 @@ final class MainViewController: UIViewController {
         let writeViewController = WriteViewController(writeViewModel: .init(currentHangdamID: viewModel.hangdam.id))
         writeViewController.delegate = self                                     // Delegate 연결
         writeViewController.modalTransitionStyle = .coverVertical               // 모달 스타일 설정
+        writeViewController.modalPresentationCapturesStatusBarAppearance = true // writeViewController의 상태바 스타일을 따르도록 설정
         present(writeViewController, animated: true)                            // 모달 표시
     }
     

--- a/Sodam/Sodam/View/Main/WriteView/WriteViewController.swift
+++ b/Sodam/Sodam/View/Main/WriteView/WriteViewController.swift
@@ -14,6 +14,11 @@ protocol WriteViewControllerDelegate: AnyObject {
 
 final class WriteViewController: UIViewController {
     
+    // 상태 바 스타일을 검은색으로 고정
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return .darkContent
+    }
+    
     weak var delegate: WriteViewControllerDelegate?
     
     private let writeViewModel: WriteViewModel


### PR DESCRIPTION
## 1. 요약 
모달 나올 때 모달 뒷 배경에 상태표시줄이 보이도록 수정했습니다.

## 2. 스크린샷 
| ![이미지1](https://github.com/user-attachments/assets/7ad42e40-a9cf-48d6-9927-a06bc542b18f) | ![이미지2](https://github.com/user-attachments/assets/a41fadd5-f637-48fa-9f36-0d1fee8fe5b4) |
|--------------------------|--------------------------|

상태표시줄 검은색으로 표시되도록 했습니다.

## 3. 공유사항
- 가장 중요한 건 메인뷰에서 작성뷰 모달 띄울 때, modalPresentationCapturesStatusBarAppearance를 true로 설정하는 것이었습니다. 모달이 표시될 때 상태 바 스타일을 해당 모달이 결정하도록 하는 속성이라고 합니다.
- 저희가 다크모드를 지원하지 않아 window 배경색이 항상 하얀색일테니, 상태바 속성을 검은색이 되도록 고정해놓은 상태입니다. 만약 다크모드 지원한다고 하면 return을 traitCollection.userInterfaceStyle를 통해 조절하면 될 것 같습니다..!