### PR TITLE
[Fix] 작성 뷰 키보드 버그 수정 / 메모리누수 해결

### DIFF
--- a/Sodam/Sodam/View/Main/WriteView/WriteView.swift
+++ b/Sodam/Sodam/View/Main/WriteView/WriteView.swift
@@ -287,6 +287,11 @@ extension WriteView {
         updatePlaceholderVisibility() // 텍스트 변경 시 Placeholder 업데이트
         updateTextViewAttributes() // 텍스트 변경 시 스타일 적용
     }
+    
+    // 텍스트뷰 입력 활성화 해제 메서드 (키보드 내리기 위함) - 작성 완료 버튼 액션 함수에서 호출
+    func dismissKeyboard() {
+        textView.resignFirstResponder()
+    }
 }
 
 // MARK: - 버튼 액션 설정

--- a/Sodam/Sodam/View/Main/WriteView/WriteViewController.swift
+++ b/Sodam/Sodam/View/Main/WriteView/WriteViewController.swift
@@ -172,6 +172,9 @@ extension WriteViewController {
             return
         }
         
+        // 키보드 내림
+        writeView.dismissKeyboard()
+        
         // 작성 완료 알림 표시
         alertManager.showCompletionAlert {
             self.writeViewModel.submitPost {

--- a/Sodam/Sodam/View/Main/WriteView/WriteViewController.swift
+++ b/Sodam/Sodam/View/Main/WriteView/WriteViewController.swift
@@ -176,10 +176,10 @@ extension WriteViewController {
         writeView.dismissKeyboard()
         
         // 작성 완료 알림 표시
-        alertManager.showCompletionAlert {
-            self.writeViewModel.submitPost {
+        alertManager.showCompletionAlert { [weak self] in
+            self?.writeViewModel.submitPost {
                 NotificationCenter.default.post(name: Notification.didWriteToday, object: nil)
-                self.dismiss(animated: true, completion: nil)
+                self?.dismiss(animated: true, completion: nil)
             }
         }
     }


### PR DESCRIPTION
## 1. 요약
1. 작성 완료 시 키보드가 잠깐 다시 나타나는 현상 해결
2. 메모리누수 해결해놨더니 다시 발생시킨 부분 다시 해결😛
## 2. 스크린샷
| before | after |
| ----- | ----- |
| ![Screen Recording 2025-02-18 at 15 15 18](https://github.com/user-attachments/assets/bd70b816-e239-49fb-9644-547ed95c4845) | ![Screen Recording 2025-02-18 at 16 07 13](https://github.com/user-attachments/assets/4a65b508-15c5-4449-bb0a-3b8a96a4c533) |
| before | after |
| ![leak](https://github.com/user-attachments/assets/fffced73-0408-4e41-aaf7-ae66783de369) | ![Screenshot 2025-02-18 at 16 12 26](https://github.com/user-attachments/assets/0d4f56a7-343e-49a1-8f50-1e074b5bb823) |
## 3. 공유사항
작성 완료 버튼을 누르는 순간 `UITextView`의 입력 모드를 끝내 키보드를 내리도록 하는 `resignFirstResponder` 메소드를 이용하여 해결했습니다.