### PR TITLE
[Feat] 글자수 제한 기능 및 입력한 글자수 표기 추가

### DIFF
--- a/Sodam/Sodam/Model/Manager/Alert/AlertTypes.swift
+++ b/Sodam/Sodam/Model/Manager/Alert/AlertTypes.swift
@@ -16,6 +16,7 @@ enum AlertMessage {
     case writeCompleted
     case cameraPermission
     case imagePermission
+    case textLimit
 
     var title: String {
         switch self {
@@ -31,6 +32,8 @@ enum AlertMessage {
             return "현재 카메라 사용에 대한 접근 권한이 없습니다."
         case .imagePermission:
             return "현재 사진 라이브러리 접근에 대한 권한이 없습니다."
+        case .textLimit:
+            return "글자 수 제한 초과"
         }
     }
 
@@ -46,6 +49,8 @@ enum AlertMessage {
             return "글이 성공적으로 작성되었습니다!"
         case .cameraPermission, .imagePermission:
             return "설정 > Sodam 탭에서 접근 권한을 활성화 해주세요."
+        case .textLimit:
+            return "최대 입력 글자는 500자 입니다."
         }
     }
 }

--- a/Sodam/Sodam/View/Main/WriteView/WriteView.swift
+++ b/Sodam/Sodam/View/Main/WriteView/WriteView.swift
@@ -109,7 +109,19 @@ class WriteView: UIView {
     }()
 
     // 버튼을 담을 컨테이너 뷰
-    private let containerView: UIView = UIView()
+    private let buttonContainerView: UIView = UIView()
+    
+    // 현재 글자 수 표기 레이블
+    private let characterCountLabel: UILabel = {
+        let label: UILabel = UILabel()
+        label.textColor = .darkGray
+        label.font = .sejongGeulggot(14)
+        label.text = "0 / 500"
+        return label
+    }()
+    
+    // 텍스트뷰와 글자수 레이블을 담을 컨테이너 뷰
+    private let textContainerView: UIView = UIView()
 
     // MARK: - 초기화
 
@@ -130,10 +142,10 @@ extension WriteView {
     private func setupUI() {
         backgroundColor = .viewBackground
 
-        containerView.addSubViews([cameraButton, imageButton, submitButton])
-
-        self.addSubViews([dateLabel, textView, placeholderLabel, collectionView, dismisslButton, containerView, topBar])
-
+        buttonContainerView.addSubViews([cameraButton, imageButton, submitButton])
+        textContainerView.addSubViews([textView, characterCountLabel])
+        self.addSubViews([dateLabel, textContainerView, placeholderLabel, collectionView, dismisslButton, buttonContainerView, topBar])
+        
         // 바 제약 조건 설정
         topBar.snp.makeConstraints { make in
             make.top.equalTo(safeAreaLayoutGuide.snp.top).offset(20)
@@ -154,7 +166,7 @@ extension WriteView {
             make.trailing.equalTo(safeAreaLayoutGuide.snp.trailing).offset(-20)
         }
 
-        containerView.snp.makeConstraints { make in
+        buttonContainerView.snp.makeConstraints { make in
             make.leading.trailing.equalTo(safeAreaLayoutGuide).inset(20)
             make.height.equalTo(safeAreaLayoutGuide.snp.height).multipliedBy(0.05)
             containerBottomConstraint = make.bottom.equalTo(safeAreaLayoutGuide.snp.bottom).inset(20).constraint
@@ -163,13 +175,24 @@ extension WriteView {
         collectionView.snp.makeConstraints { make in
             make.leading.trailing.equalTo(safeAreaLayoutGuide).inset(20)
             make.height.equalTo(safeAreaLayoutGuide.snp.width).multipliedBy(0.25)
-            make.bottom.equalTo(containerView.snp.top)
+            make.bottom.equalTo(buttonContainerView.snp.top)
         }
 
-        textView.snp.makeConstraints { make in
+        textContainerView.snp.makeConstraints { make in
             make.top.equalTo(dateLabel.snp.bottom).offset(20)
             make.bottom.equalTo(collectionView.snp.top)
             make.leading.trailing.equalTo(safeAreaLayoutGuide).inset(20)
+        }
+        
+        characterCountLabel.snp.makeConstraints { make in
+            make.height.equalTo(20)
+            make.trailing.equalToSuperview().offset(-8)
+            make.bottom.equalToSuperview().offset(-12)
+        }
+        
+        textView.snp.makeConstraints { make in
+            make.top.leading.trailing.equalToSuperview()
+            make.bottom.equalTo(characterCountLabel.snp.top)
         }
 
         placeholderLabel.snp.makeConstraints { make in
@@ -177,7 +200,7 @@ extension WriteView {
         }
 
         cameraButton.snp.makeConstraints { make in
-            make.bottom.equalTo(containerView.snp.bottom)
+            make.bottom.equalTo(buttonContainerView.snp.bottom)
             make.width.height.equalTo(36)
             make.leading.equalTo(textView.snp.leading)
         }
@@ -221,19 +244,19 @@ extension WriteView {
                 make.height.equalTo(0)
             }
 
-            textView.snp.remakeConstraints { make in
+            textContainerView.snp.remakeConstraints { make in
                 make.top.equalTo(dateLabel.snp.bottom).offset(20)
                 make.leading.trailing.equalTo(safeAreaLayoutGuide).inset(20)
-                make.bottom.equalTo(containerView.snp.top)
+                make.bottom.equalTo(buttonContainerView.snp.top)
             }
         } else {
             collectionView.snp.remakeConstraints { make in
                 make.leading.trailing.equalTo(safeAreaLayoutGuide).inset(20)
                 make.height.equalTo(safeAreaLayoutGuide.snp.width).multipliedBy(0.25)
-                make.bottom.equalTo(containerView.snp.top)
+                make.bottom.equalTo(buttonContainerView.snp.top)
             }
 
-            textView.snp.remakeConstraints { make in
+            textContainerView.snp.remakeConstraints { make in
                 make.top.equalTo(dateLabel.snp.bottom).offset(20)
                 make.bottom.equalTo(collectionView.snp.top)
                 make.leading.trailing.equalTo(safeAreaLayoutGuide).inset(20)
@@ -291,6 +314,11 @@ extension WriteView {
     // 텍스트뷰 입력 활성화 해제 메서드 (키보드 내리기 위함) - 작성 완료 버튼 액션 함수에서 호출
     func dismissKeyboard() {
         textView.resignFirstResponder()
+    }
+    
+    // 현재 글자수 표시 메서드
+    func setCharacterLimitLabel(_ limit: Int) {
+        characterCountLabel.text = "\(limit) / 500"
     }
 }
 

--- a/Sodam/Sodam/View/Main/WriteView/WriteViewController.swift
+++ b/Sodam/Sodam/View/Main/WriteView/WriteViewController.swift
@@ -56,6 +56,8 @@ final class WriteViewController: UIViewController {
 
         // 임시 저장글 있는지 확인하고 로드
         writeViewModel.loadTemporaryPost()
+        let currentCount = writeView.getTextViewText().count
+        writeView.setCharacterLimitLabel(currentCount)
     }
 
     override func viewDidLoad() {
@@ -298,16 +300,17 @@ extension WriteViewController: WriteViewModelDelegate {
 // MARK: - 텍스트뷰 deleage 설정
 extension WriteViewController: UITextViewDelegate {
     func textViewDidChange(_ textView: UITextView) {
-        // 텍스트가 변경될 때마다 뷰모델에 전달
-        writeViewModel.updateText(textView.text)
-        
         let maxCharacterCount = 500 // 글자 수 제한
-        
+        let limitedText = String(textView.text.prefix(maxCharacterCount))
+
         // 글자 수 제한 초과하면 Alert 띄우기
         if textView.text.count > maxCharacterCount {
             alertManager.showAlert(alertMessage: .textLimit)
-            writeView.setTextViewText(String(textView.text.prefix(maxCharacterCount))) // 초과된 부분 삭제
+            writeView.setTextViewText(limitedText) // 초과된 부분 삭제
         }
+        
+        // 텍스트가 변경될 때마다 뷰모델에 전달
+        writeViewModel.updateText(limitedText)
         
         // 현재 글자 수 전달
         let currentCount = textView.text.count

--- a/Sodam/Sodam/View/Main/WriteView/WriteViewController.swift
+++ b/Sodam/Sodam/View/Main/WriteView/WriteViewController.swift
@@ -74,6 +74,9 @@ final class WriteViewController: UIViewController {
 
         // UITextView의 delegate 설정
         writeView.setTextViewDeleaget(delegate: self)
+        
+        // 이미지 추가 여부 확인 후 컬렉션뷰 레이아웃 조정
+        writeView.updateCollectionViewConstraint(writeViewModel.imageCount == 0)
     }
 
     // 모달 dismiss 될 때 호출될 메서드
@@ -297,5 +300,17 @@ extension WriteViewController: UITextViewDelegate {
     func textViewDidChange(_ textView: UITextView) {
         // 텍스트가 변경될 때마다 뷰모델에 전달
         writeViewModel.updateText(textView.text)
+        
+        let maxCharacterCount = 500 // 글자 수 제한
+        
+        // 글자 수 제한 초과하면 Alert 띄우기
+        if textView.text.count > maxCharacterCount {
+            alertManager.showAlert(alertMessage: .textLimit)
+            writeView.setTextViewText(String(textView.text.prefix(maxCharacterCount))) // 초과된 부분 삭제
+        }
+        
+        // 현재 글자 수 전달
+        let currentCount = textView.text.count
+        writeView.setCharacterLimitLabel(currentCount)
     }
 }


### PR DESCRIPTION
## 1. 요약 
- 글자수 제한 기능 추가했고, 일단 500자로 제한 하였습니다.
- 작성된 글자수도 0 / 500 이런식으로 표기되도록 추가했습니다.

## 2. 스크린샷 
| <img src="https://github.com/user-attachments/assets/3c3f6a95-0d3e-4495-ac38-26936f32c646" alt="이미지1" width="300"> | <img src="https://github.com/user-attachments/assets/bb8c850c-da19-4a0c-9f2d-145d2ca61caf" alt="이미지2" width="300"> | <img src="https://github.com/user-attachments/assets/19361a42-0600-47df-bc11-daf8c8a8e3ec" alt="이미지2" width="300"> |
|-------------------------------------------------------|-------------------------------------------------------|-------------------------------------------------------|
|아무 입력도 안 했을 때|글자 입력했을 때 카운트 증가|키보드 없을 때 레이아웃|

| <img src="https://github.com/user-attachments/assets/f44b6b83-48a4-4fda-bd28-6c309e2e8860" alt="이미지1" width="250"> | <img src="https://github.com/user-attachments/assets/877a8b97-52ee-4c59-ac27-b2d69da670e6" alt="이미지2" width="250"> |
|-------------------------------------------------------|-------------------------------------------------------|
|500자 입력시 레이아웃|제한 초과했을 때 Alert|

| <img src="https://github.com/user-attachments/assets/57766b60-d55c-478e-8892-b5f12d70366f" alt="이미지1" width="250"> | <img src="https://github.com/user-attachments/assets/da1cc1d5-3582-47cb-b922-823bd80783bd" alt="이미지2" width="250"> |
|-------------------------------------------------------|-------------------------------------------------------|
|500자 입력 키보드 없을 때 레이아웃 |긴 글 중간 편집할 때 레이아웃|

| <img src="https://github.com/user-attachments/assets/6ed4eab7-bf51-48e8-9f4d-485662e2403d" alt="이미지1" width="250"> | <img src="https://github.com/user-attachments/assets/6a3ce4fe-7e39-4caf-8ff9-df9ad87f7a9e" alt="이미지2" width="250"> |
|-------------------------------------------------------|-------------------------------------------------------|
|긴 글 입력후 사진 추가 할 떄 레이아웃|긴 글과 사진, 키보드 있을 떄 레이아웃|

다양한 경우의 스크린샷을 찍은 이유는 
- 긴 글이 입력 되었을 때
- 글을 편집하려고 커서를 글 중간에 놓을 때
- 사진이 추가 되었을 때

위와 같은 경우에 Label이 글자와 겹쳤어서, 아예 안 겹치게 textView 바깥에 놓았는데 어떻게 보이는지 궁금해서 입니당

## 3. 공유사항
- 글자 수 제한이 넘은 경우 prefix를 이용해 제한 안에 들어오는 글자만 다시 입력되는 형식으로 글자수 제한 구현하였고, alert 띄워 글자수 초과되었다는 것을 알도록 하였습니다.
- 글자 수 표기 Label을 텍스트뷰 우측 하단에 두었습니다.
- 글 입력중이 아닐 때(키보드가 없을때) Label이 다소 과하게 하단에 있는 느낌이라 고민이었는데, PR 작성하면서 다시보니 큰 문제 없어 보이네요..🤔