### PR TITLE
[Fix] 일기 작성 시간 확인 후 알림시간 전 작성완료 시 알림 안울리게 코드 수정

### DIFF
--- a/Sodam/Sodam/Delegate/SceneDelegate.swift
+++ b/Sodam/Sodam/Delegate/SceneDelegate.swift
@@ -53,6 +53,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         })
     }
     
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        UIApplication.shared.applicationIconBadgeNumber = 0
+    }
+    
     // 앱이 백그라운드로 전환될 때 일기 작성 여부 확인
     func sceneDidEnterBackground(_ scene: UIScene) {
         LocalNotificationManager.shared.checkDiaryAndCancelNotification()

--- a/Sodam/Sodam/Delegate/SceneDelegate.swift
+++ b/Sodam/Sodam/Delegate/SceneDelegate.swift
@@ -52,4 +52,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             overlayView.removeFromSuperview() // 오버레이 제거
         })
     }
+    
+    // 앱이 백그라운드로 전환될 때 일기 작성 여부 확인
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        LocalNotificationManager.shared.checkDiaryAndCancelNotification()
+    }
 }

--- a/Sodam/Sodam/Model/Manager/Alert/AlertManager.swift
+++ b/Sodam/Sodam/Model/Manager/Alert/AlertManager.swift
@@ -165,16 +165,9 @@ final class AlertManager {
             preferredStyle: .alert
         )
         
-        let cancelAction = UIAlertAction(title: "취소", style: .cancel) { [weak self] _ in
-            guard self != nil else {
-                return
-            }
-        }
-        
-        let settingsAction = UIAlertAction(title: "설정으로 이동", style: .default) { [weak self] _ in
-            guard self != nil else {
-                return
-            }
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel, handler: nil)
+
+        let settingsAction = UIAlertAction(title: "설정으로 이동", style: .default) { _ in
             if let url = URL(string: UIApplication.openSettingsURLString),
                UIApplication.shared.canOpenURL(url) {
                 UIApplication.shared.open(url, options: [:])

--- a/Sodam/Sodam/Model/Manager/Alert/AlertManager.swift
+++ b/Sodam/Sodam/Model/Manager/Alert/AlertManager.swift
@@ -155,4 +155,35 @@ final class AlertManager {
         // contains로 금지어들 중에 포함되면 true를 반환 시킴
         return ForbiddenWords.list.contains { text.contains($0) }
     }
+    
+    // MARK: - SettingViewController Alert
+    // 시스템 설정 거부 상태시 토글 on 할때 시스템 설정으로 이동을 요청 팝업
+    func showNotificationPermissionAlert() {
+        let alertController = UIAlertController(
+            title: "알림 권한 필요",
+            message: "앱의 알림을 받으려면 설정에서 알림을 허용해주세요.",
+            preferredStyle: .alert
+        )
+        
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel) { [weak self] _ in
+            guard self != nil else {
+                return
+            }
+        }
+        
+        let settingsAction = UIAlertAction(title: "설정으로 이동", style: .default) { [weak self] _ in
+            guard self != nil else {
+                return
+            }
+            if let url = URL(string: UIApplication.openSettingsURLString),
+               UIApplication.shared.canOpenURL(url) {
+                UIApplication.shared.open(url, options: [:])
+            }
+        }
+        
+        alertController.addAction(cancelAction)
+        alertController.addAction(settingsAction)
+        
+        viewController?.present(alertController, animated: true)
+    }
 }

--- a/Sodam/Sodam/Model/Manager/LocalNotificationManager.swift
+++ b/Sodam/Sodam/Model/Manager/LocalNotificationManager.swift
@@ -10,93 +10,143 @@ import UIKit
 
 final class LocalNotificationManager: NSObject {
     static let shared = LocalNotificationManager()
-
+    private let notificationCenter = UNUserNotificationCenter.current()   // 앱의 로컬 및 푸시 알림을 관리하는 중심 객체로 알림 센터 객체를 가져옵
+    
     private override init() {
         super.init()
-        UNUserNotificationCenter.current().delegate = self
-        UserDefaultsManager.shared.resetDiaryWrittenStatusAtMidnight()
+        notificationCenter.delegate = self
     }
 
-    // 초기 설정 체크
-    func checkInitialSetup() {
-        let center = UNUserNotificationCenter.current()
-        // 알림 권한 설정을 비동기로 확인(center.getNotificationSettings)하고 그 결과에 따라 처리
-        center.getNotificationSettings { [weak self] settings in
-            self?.handleNotificationAuthorizationStatus(settings.authorizationStatus)
-        }
-    }
-
-    // 알림 권한 상태 처리
-    private func handleNotificationAuthorizationStatus(_ status: UNAuthorizationStatus) {
-        switch status {
-        // 권한이 아직 결정되지 않은 경우 권한 요청
-        case .notDetermined:
-            // 권한 요청
-            requestNotificationAuthorization { [weak self] granted in
-                if granted {
-                    // 권한이 허가되면 기본 알림 설정
-                    self?.setNotificationState(granted)
-                }
+    // MARK: - LocalNotification
+    func checkAuthorization(completion: @escaping (Bool) -> Void) {
+        notificationCenter.getNotificationSettings { settings in
+            DispatchQueue.main.async {
+                self.handleNotificationAuthorizationStatus(settings.authorizationStatus, completion: completion)
             }
-        // 권한이 거부된 경우 안내 메시지 표시
-        case .denied:
-            showDeniedToastOnce()
-
-        // 권한이 이미 허가되었거나 임시 허가된 경우 기본 알림 설정
-        case .authorized, .provisional, .ephemeral:
-            let appToggle = UserDefaultsManager.shared.getAppNotificationToggleState()
-            setNotificationState(appToggle)
-
-        @unknown default:
-            break
         }
     }
 
-    // 알림 권한 요청 (최초 1회만 실행)
-    private func requestNotificationAuthorization(completion: @escaping (Bool) -> Void) {
-        // 이미 권한이 설정되어 있는 경우 요청하지 않음
-        guard !UserDefaultsManager.shared.getNotificaionAuthorizationStatus() else {
+    // 알림 권한 여부 체크 확인 후 실행
+    private func handleNotificationAuthorizationStatus(_ status: UNAuthorizationStatus, completion: @escaping (Bool) -> Void) {
+        switch status {
+        // 권한 설정 한적이 없는 경우
+        case .notDetermined:
+            print("권한 설정 한적이 없는 경우")
+            requestAuthorization { [weak self] granted in
+                guard let self = self else {
+                    return
+                }
+                self.updateNotificationPermissionStatus(granted)
+                completion(granted)
+            }
+            
+        // 거부 인 경우
+        case .denied:
+            print("거부인 경우")
+            showNotificationDeniedAlert()
+            completion(false)
+            
+        // 허용 인 경우
+        case .authorized:
+            print("허용인 경우")
+            updateNotificationPermissionStatus(true)
             completion(true)
+            
+        // 임시 또는 제한적 권한 상태에서의 처리
+        case .provisional, .ephemeral:
+            updateNotificationPermissionStatus(true)
+            completion(true)
+            
+        @unknown default:
+            completion(false)
+        }
+    }
+
+    // 알림 권한 설정 (팝업 자체는 자동적으로 앱 첫 진입시에만 노출)
+    func requestAuthorization(completion: @escaping (Bool) -> Void) {
+        let options: UNAuthorizationOptions = [.alert, .badge, .sound]   //
+        
+        // 앱의 로컬 및 푸시 알림을 관리하는 중심 객체로 알림 센터 객체를 가져옵
+        notificationCenter.requestAuthorization(options: options) { granted, error in
+            if let error = error {
+                print("Notification Authorization Error: \(error.localizedDescription)")
+            }
+            // 허용을 누르면 granted == true, 거부하면 granted == false
+            completion(granted)
+        }
+    }
+
+    // 알림 권한 체크
+    func updateNotificationPermissionStatus(_ isGranted: Bool) {
+        // 이미 알림 권한이 설정된 경우, false 일때 return
+        guard !UserDefaultsManager.shared.isNotificationSetupComplete() else {
+            print("!UserDefaultsManager.shared.isNotificationSetupComplete() \(!UserDefaultsManager.shared.isNotificationSetupComplete())")
             return
         }
 
-        let center = UNUserNotificationCenter.current()
-        let options: UNAuthorizationOptions = [.alert, .badge, .sound]
-
-        center.requestAuthorization(options: options) { [weak self] granted, _ in
-            UserDefaultsManager.shared.saveNotificaionAuthorizationStatus(true)
-
-            if granted {
-                // 권한이 허가여부를 UserDefaults에 저장(true가 허용)
-                completion(true)
-            } else {
-                // 권한이 거부된 경우 안내 메시지 표시(false가 거부)
-                self?.showDeniedToastOnce()
-                completion(false)
-            }
-        }
-    }
-
-    func checkNotificationAuthorizationStatus(completion: @escaping (Bool) -> Void) {
-        UNUserNotificationCenter.current().getNotificationSettings { settings in
+        // 허용인 경우
+        if isGranted {
+            print("알림이 허용되었습니다.\(isGranted)")
+            // 허용한 경우 UserDefault에 시스템 상태 true, 앱 토글 true로 저장
+            UserDefaultsManager.shared.saveNotificaionAuthorizationStatus(isGranted)
+            UserDefaultsManager.shared.saveAppToggleState(isGranted)
+            
+            // 알림 초기 설정을 완료
+            UserDefaultsManager.shared.markNotificationSetupAsComplete()
+            
+            // 처음 시스템 허용한 경우 오후 9시 기본 알림 시간 설정
+            let calendar = Calendar.current
+            let defaultTime = calendar.date(bySettingHour: 21, minute: 0, second: 0, of: Date())!
+            //setReservedNotification(defaultTime)
+            UserDefaultsManager.shared.saveNotificationTime(defaultTime)
+            
+            // 알림 권한 거부 메시지 표시
             DispatchQueue.main.async {
-                let isAuthorized = settings.authorizationStatus == .authorized
-                UserDefaultsManager.shared.saveNotificaionAuthorizationStatus(isAuthorized)
-                completion(isAuthorized)
+                ToastManager.shared.showToastMessage(message: "알림 권한이 허용되었습니다")
             }
+
+            // 거부인 경우
+        } else {
+            print("알림이 거부되었습니다.")
+            showNotificationDeniedAlert()
         }
     }
 
-    // 알림 시간 설정 (사용자가 설정한 시간)
+    // 거부 인 경우
+    func showNotificationDeniedAlert() {
+        // 이미 알림 권한이 설정된 경우 return
+        guard !UserDefaultsManager.shared.isNotificationSetupComplete() else {
+            return
+        }
+
+        // UserDefault에 시스템 상태 false, 앱 토글 false로 저장
+        UserDefaultsManager.shared.saveNotificaionAuthorizationStatus(false)
+        UserDefaultsManager.shared.saveAppToggleState(false)
+        // 알림 초기 설정을 완료
+        UserDefaultsManager.shared.markNotificationSetupAsComplete()
+        
+        // 알림 권한 거부 메시지 표시
+        DispatchQueue.main.async {
+            ToastManager.shared.showToastMessage(message: "알림 권한이 거부되었습니다")
+        }
+    }
+}
+
+    // MARK: - 알림 예약 관련 시간/내용/트리거 설정
+
+extension LocalNotificationManager {
+    // 알림 시간 설정
     func setReservedNotification(_ time: Date) {
         let identifier = "SelectedTimeNotification"
 
         // 일기 작성 상태 확인
         if UserDefaultsManager.shared.getDiaryWrittenStatus() {
-            DispatchQueue.main.async {
-                ToastManager.shared.showToastMessage(message: "알림 시간이\n\(self.timeFormatted(time))로 설정되었습니다")
+            // 일기 작성 시간이 현재 시간 이후인 경우 알림을 울리지 않음
+            if let diaryWrittenTime = UserDefaultsManager.shared.markDiaryAsWritten() as? Date {
+                if Calendar.current.isDateInToday(diaryWrittenTime) && diaryWrittenTime > time {
+                    return // 일기 작성 시간이 알림 시간 이후면 알림 예약하지 않음
+                }
             }
-            return
         }
 
         // 현재 대기 중인 알림 요청을 가져와서 새로운 알림 예약
@@ -113,7 +163,7 @@ final class LocalNotificationManager: NSObject {
             let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
 
             // 알림을 UNUserNotificationCenter에 추가
-            UNUserNotificationCenter.current().add(request) { [weak self] error in
+            self.notificationCenter.add(request) { [weak self] error in
                 if let error = error {
                     // 알림 등록 실패 시 에러 메시지 표시
                     DispatchQueue.main.async {
@@ -121,11 +171,7 @@ final class LocalNotificationManager: NSObject {
                     }
                 } else {
                     // 알림이 성공적으로 등록된 후 후속 처리
-                    self?.handleNotificationScheduling(
-                        identifier: identifier,
-                        time: time,
-                        existingRequests: existingRequests
-                    )
+                    self?.handleNotificationScheduling(identifier: identifier, time: time, existingRequests: existingRequests)
                 }
             }
         }
@@ -138,10 +184,10 @@ final class LocalNotificationManager: NSObject {
             content.title = "Sodam"
             content.body = "소소한 행복을 적어 행담이를 키워주세요."
             content.sound = .default
-
+            
             let currentBadgeNumber = UIApplication.shared.applicationIconBadgeNumber
             content.badge = NSNumber(value: currentBadgeNumber + 1)
-
+            
             completion(content) // 비동기로 content를 반환
         }
     }
@@ -157,17 +203,12 @@ final class LocalNotificationManager: NSObject {
 
     // MARK: - 알림 예약 후 처리
 
-    private func handleNotificationScheduling(
-        identifier: String,
-        time: Date,
-        existingRequests: [UNNotificationRequest]
-    ) {
+    private func handleNotificationScheduling(identifier: String, time: Date, existingRequests: [UNNotificationRequest]) {
         // 이미 동일한 알림이 예약되어 있는지 확인
         let isAlreadyScheduled = existingRequests.contains { $0.identifier == identifier }
         DispatchQueue.main.async {
-            // 알림이 새로 예약되었거나 시간이 변경되었음을 사용자에게 알림
-            let message = isAlreadyScheduled ? "알림 시간이 \(self.timeFormatted(time))로 변경되었습니다" : "알림 시간이\n\(self.timeFormatted(time))로 설정되었습니다"
-            ToastManager.shared.showToastMessage(message: message)
+            // 알림 권한이 처음 허용되었을 때만 메시지 표시
+            ToastManager.shared.showToastMessage(message: "알림 시간이 \(self.timeFormatted(time))로 설정되었습니다")
         }
     }
 
@@ -180,72 +221,17 @@ final class LocalNotificationManager: NSObject {
     }
 }
 
-// MARK: - Private Methods
-
-private extension LocalNotificationManager {
-    func setNotificationState(_ status: Bool) {
-        guard !UserDefaultsManager.shared.isNotificationSetupComplete() else {
-            return
-        }
-
-        let calendar = Calendar.current
-        let defaultTime = calendar.date(bySettingHour: 21, minute: 0, second: 0, of: Date())!
-
-        UserDefaultsManager.shared.saveNotificaionAuthorizationStatus(status)
-        UserDefaultsManager.shared.saveAppNotificationToggleState(status)
-        UserDefaultsManager.shared.saveNotificationTime(defaultTime)
-        UserDefaultsManager.shared.markNotificationSetupAsComplete()  // 기본 알림 설정 완료 상태를 저장
-
-        setReservedNotification(defaultTime)  // 기본 알림 설정을 예약
-    }
-
-    // 알림 권한이 거부된 경우 사용자에게 한 번만 안내 메시지 제공
-    func showDeniedToastOnce() {
-        // 알림 권한 설정 확인
-        guard !UserDefaultsManager.shared.isNotificationSetupComplete() else {
-            return
-        }
-
-        // 권한이 거부된 상태를 UserDefaults에 저장
-        UserDefaultsManager.shared.saveNotificaionAuthorizationStatus(false)
-        UserDefaultsManager.shared.saveAppNotificationToggleState(false)
-
-        // 알림 권한 거부 메시지 표시
-        DispatchQueue.main.async {
-            ToastManager.shared.showToastMessage(message: "알림 권한이 거부되었습니다")
-        }
-        UserDefaultsManager.shared.markNotificationSetupAsComplete()  // 기본 알림 설정 완료 상태를 저장
-    }
-
-    // MARK: - Diary State Management
-
-    func markDiaryAsWritten() {
-        let calendar = Calendar.current
-        let startOfDay = calendar.startOfDay(for: Date())
-
-        UserDefaultsManager.shared.saveDiaryWrittenDate(startOfDay)
-    }
-}
-
 // MARK: - UNUserNotificationCenterDelegate
 
 extension LocalNotificationManager: UNUserNotificationCenterDelegate {
     // Foreground 상태에서 알림을 수신할 때 호출
-    func userNotificationCenter(
-        _ center: UNUserNotificationCenter,
-        willPresent notification: UNNotification,
-        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
-    ) {
+    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         UIApplication.shared.applicationIconBadgeNumber += 1  // 배지 번호를 증가시켜 앱 아이콘에 표시
         completionHandler([.banner, .badge, .sound, .list])
     }
 
     // Background에서 알림을 클릭했을 때 호출
-    func userNotificationCenter(
-        _ center: UNUserNotificationCenter,
-        didReceive response: UNNotificationResponse,
-        withCompletionHandler completionHandler: @escaping () -> Void
-    ) {
+    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
         completionHandler() // 응답 처리 완료
     }
 }

--- a/Sodam/Sodam/Model/Manager/LocalNotificationManager.swift
+++ b/Sodam/Sodam/Model/Manager/LocalNotificationManager.swift
@@ -88,12 +88,7 @@ final class LocalNotificationManager: NSObject {
         if isGranted {
             print("알림이 허용되었습니다.\(isGranted)")
             // 허용한 경우 UserDefault에 시스템 상태 true, 앱 토글 true로 저장
-            UserDefaultsManager.shared.saveNotificaionAuthorizationStatus(isGranted)
             UserDefaultsManager.shared.saveAppToggleState(isGranted)
-            
-            // 알림 초기 설정을 완료
-            UserDefaultsManager.shared.markNotificationSetupAsComplete()
-            
             // 처음 시스템 허용한 경우 오후 9시 기본 알림 시간 설정
             setDefaultNotification()
 
@@ -111,11 +106,8 @@ final class LocalNotificationManager: NSObject {
             return
         }
 
-        // UserDefault에 시스템 상태 false, 앱 토글 false로 저장
-        UserDefaultsManager.shared.saveNotificaionAuthorizationStatus(false)
+        // UserDefault에 앱 토글 false로 저장
         UserDefaultsManager.shared.saveAppToggleState(false)
-        // 알림 초기 설정을 완료
-        UserDefaultsManager.shared.markNotificationSetupAsComplete()
         
         // 알림 권한 거부 메시지 표시
         DispatchQueue.main.async {

--- a/Sodam/Sodam/Model/Manager/LocalNotificationManager.swift
+++ b/Sodam/Sodam/Model/Manager/LocalNotificationManager.swift
@@ -93,6 +93,11 @@ final class LocalNotificationManager: NSObject {
             UserDefaultsManager.shared.markNotificationSetupAsComplete()
             UserDefaultsManager.shared.saveNotificationAuthorizationStatus(isGranted)
             
+            // 알림 권한 허용 메시지 표시
+            DispatchQueue.main.async {
+                ToastManager.shared.showToastMessage(message: "알림 권한이 허용되었습니다")
+            }
+            
             // 처음 시스템 허용한 경우 오후 9시 기본 알림 시간 설정
             setDefaultNotification()
             
@@ -154,13 +159,6 @@ extension LocalNotificationManager {
                     // 알림 등록 실패 시 에러 메시지 표시
                     DispatchQueue.main.async {
                         ToastManager.shared.showToastMessage(message: "알림 등록 실패: \(error.localizedDescription)")
-                    }
-                } else if showToast {
-                    // 알림이 성공적으로 등록된 후 후속 처리
-                    DispatchQueue.main.async {
-                        // String Interpolation을 사용하여 옵셔널 값을 안전하게 처리
-                        let formattedTime = self?.timeFormatted(time) ?? "알 수 없는 시간"
-                        ToastManager.shared.showToastMessage(message: "알림 시간이 \(formattedTime)로 설정되었습니다")
                     }
                 }
             }

--- a/Sodam/Sodam/Model/Manager/LocalNotificationManager.swift
+++ b/Sodam/Sodam/Model/Manager/LocalNotificationManager.swift
@@ -138,14 +138,14 @@ extension LocalNotificationManager {
     // 알림 시간 설정
     func setReservedNotification(_ time: Date) {
         let identifier = "SelectedTimeNotification"
-
-        // 일기 작성 상태 확인
-        if UserDefaultsManager.shared.getDiaryWrittenStatus() {
-            // 일기 작성 시간이 현재 시간 이후인 경우 알림을 울리지 않음
-            if let diaryWrittenTime = UserDefaultsManager.shared.markDiaryAsWritten() as? Date {
-                if Calendar.current.isDateInToday(diaryWrittenTime) && diaryWrittenTime > time {
-                    return // 일기 작성 시간이 알림 시간 이후면 알림 예약하지 않음
-                }
+                
+        // 저장된 일기 작성 시간 가져오기
+        if let diaryWrittenTime = UserDefaultsManager.shared.getDiaryWrittenTime() {
+            print("저장된 일기 작성 시간: \(self.timeFormatted(diaryWrittenTime))")
+            
+            // 일기 작성 시간이 알림 시간보다 같거나 빠르면 알림 예약하지 않음
+            if diaryWrittenTime <= time {
+                return
             }
         }
 

--- a/Sodam/Sodam/Model/Manager/LocalNotificationManager.swift
+++ b/Sodam/Sodam/Model/Manager/LocalNotificationManager.swift
@@ -89,10 +89,14 @@ final class LocalNotificationManager: NSObject {
             print("알림이 허용되었습니다.\(isGranted)")
             // 허용한 경우 UserDefault에 시스템 상태 true, 앱 토글 true로 저장
             UserDefaultsManager.shared.saveAppToggleState(isGranted)
+            
+            UserDefaultsManager.shared.markNotificationSetupAsComplete()
+            UserDefaultsManager.shared.saveNotificationAuthorizationStatus(isGranted)
+            
             // 처음 시스템 허용한 경우 오후 9시 기본 알림 시간 설정
             setDefaultNotification()
-
-        // 거부인 경우
+            
+            // 거부인 경우
         } else {
             print("알림이 거부되었습니다.")
             showNotificationDeniedAlert()
@@ -108,7 +112,8 @@ final class LocalNotificationManager: NSObject {
 
         // UserDefault에 앱 토글 false로 저장
         UserDefaultsManager.shared.saveAppToggleState(false)
-        
+        UserDefaultsManager.shared.markNotificationSetupAsComplete()
+        UserDefaultsManager.shared.saveNotificationAuthorizationStatus(false)
         // 알림 권한 거부 메시지 표시
         DispatchQueue.main.async {
             ToastManager.shared.showToastMessage(message: "알림 권한이 거부되었습니다")

--- a/Sodam/Sodam/Model/Manager/LocalNotificationManager.swift
+++ b/Sodam/Sodam/Model/Manager/LocalNotificationManager.swift
@@ -139,14 +139,9 @@ extension LocalNotificationManager {
     func setReservedNotification(_ time: Date) {
         let identifier = "SelectedTimeNotification"
                 
-        // 저장된 일기 작성 시간 가져오기
-        if let diaryWrittenTime = UserDefaultsManager.shared.getDiaryWrittenTime() {
-            print("저장된 일기 작성 시간: \(self.timeFormatted(diaryWrittenTime))")
-            
-            // 일기 작성 시간이 알림 시간보다 같거나 빠르면 알림 예약하지 않음
-            if diaryWrittenTime <= time {
-                return
-            }
+        // 일기가 작성된 경우 알림 울리지않도록 return
+        if UserDefaultsManager.shared.hasAlreadyWrittenToday() {
+            return
         }
 
         // 현재 대기 중인 알림 요청을 가져와서 새로운 알림 예약

--- a/Sodam/Sodam/Model/Manager/LocalNotificationManager.swift
+++ b/Sodam/Sodam/Model/Manager/LocalNotificationManager.swift
@@ -139,7 +139,7 @@ final class LocalNotificationManager: NSObject {
 
 extension LocalNotificationManager {
     // datePicker에서 사용자가 알림 시간을 설정할 때 호출
-    func setUserNotification(time: Date, showToast: Bool) {
+    func setUserNotification(time: Date) {
         let identifier = "SelectedTimeNotification"
         // 기존 알림이 있으면 삭제
         notificationCenter.removePendingNotificationRequests(withIdentifiers: [identifier])
@@ -147,7 +147,7 @@ extension LocalNotificationManager {
     }
 
     // 알림 예약
-    private func scheduleNotification(time: Date, identifier: String, showToast: Bool = true) {
+    private func scheduleNotification(time: Date, identifier: String) {
         createNotificationContent { content in
             // 알림을 트리거할 시간 설정
             let trigger = self.createNotificationTrigger(for: time)
@@ -213,7 +213,7 @@ extension LocalNotificationManager {
             if !isNotificationScheduled {
                 DispatchQueue.main.async {
                     let now = Date()
-                    self.setUserNotification(time: now, showToast: false) // Foreground에서는 토스트 메시지 표시 안 함
+                    self.setUserNotification(time: now) // Foreground에서는 토스트 메시지 표시 안 함
                     UserDefaultsManager.shared.saveNotificationTime(now)
                 }
             }

--- a/Sodam/Sodam/Model/Manager/UserDefaultsManager.swift
+++ b/Sodam/Sodam/Model/Manager/UserDefaultsManager.swift
@@ -52,23 +52,6 @@ final class UserDefaultsManager {
     func saveAppToggleState(_ isOn: Bool) {
         userDefaults.set(isOn, forKey: Keys.appSettingToggleState)
     }
-    
-    // 알림 권한 상태 (허용/거부)를 UserDefaults에 저장
-    func saveNotificaionAuthorizationStatus(_ isAuthorized: Bool) {
-        userDefaults.set(isAuthorized, forKey: Keys.notificationAuthorizationStatus)
-    }
-
-    // 오늘 일기 작성했는지 확인하는 메서드
-    func hasAlreadyWrittenToday() -> Bool {
-        let lastWrittenDate = UserDefaults.standard.object(forKey: "lastWrittenDate") as? Date ?? Date.distantPast
-        let calendar = Calendar.current
-        return calendar.isDateInToday(lastWrittenDate)
-    }
-
-    // 알림 초기 설정 완료 여부를 확인 (알림 설정이 처음 완료되었는지 여부)
-    func isNotificationSetupComplete() -> Bool {
-        return userDefaults.bool(forKey: Keys.notificationInitialSetupComplete)
-    }
 
     // MARK: - 작성 뷰 Get
 
@@ -88,14 +71,32 @@ final class UserDefaultsManager {
         userDefaults.removeObject(forKey: Keys.content)
         userDefaults.removeObject(forKey: Keys.imagePath)
     }
-
-    // MARK: - Local Notification Get
-
+    
     // 알림 초기 설정을 완료 표시 (true가 완료, false가 미완료)
     func markNotificationSetupAsComplete() {
         userDefaults.set(true, forKey: Keys.notificationInitialSetupComplete)
     }
 
+    // 오늘 작성했다고 UserDefaults에 저장 (시간 포함)
+    func markAsWrittenToday() {
+        let today = Calendar.current.startOfDay(for: Date())  // 시간을 00:00:00으로 초기화
+        UserDefaults.standard.set(today, forKey: "lastWrittenDate") // UserDefaults에 저장
+    }
+
+    // MARK: - Local Notification Get
+
+    // 오늘 일기 작성했는지 확인하는 메서드
+    func hasAlreadyWrittenToday() -> Bool {
+        let lastWrittenDate = UserDefaults.standard.object(forKey: "lastWrittenDate") as? Date ?? Date.distantPast
+        let calendar = Calendar.current
+        return calendar.isDateInToday(lastWrittenDate)
+    }
+    
+    // 알림 초기 설정 완료 여부를 확인 (알림 설정이 처음 완료되었는지 여부)
+    func isNotificationSetupComplete() -> Bool {
+        return userDefaults.bool(forKey: Keys.notificationInitialSetupComplete)
+    }
+    
     // 앱 설정 알림 토글 상태 (ON/OFF)를 가져옴
     func getAppToggleState() -> Bool {
         userDefaults.bool(forKey: Keys.appSettingToggleState)
@@ -109,11 +110,5 @@ final class UserDefaultsManager {
     // 저장된 알림 시간을 가져옴
     func getNotificationTime() -> Date? {
         userDefaults.object(forKey: Keys.notificationTime) as? Date
-    }
-
-    // 오늘 작성했다고 UserDefaults에 저장 (시간 포함)
-    func markAsWrittenToday() {
-        let today = Calendar.current.startOfDay(for: Date())  // 시간을 00:00:00으로 초기화
-        UserDefaults.standard.set(today, forKey: "lastWrittenDate") // UserDefaults에 저장
     }
 }

--- a/Sodam/Sodam/Model/Manager/UserDefaultsManager.swift
+++ b/Sodam/Sodam/Model/Manager/UserDefaultsManager.swift
@@ -52,6 +52,10 @@ final class UserDefaultsManager {
     func saveAppToggleState(_ isOn: Bool) {
         userDefaults.set(isOn, forKey: Keys.appSettingToggleState)
     }
+    
+    func saveNotificationAuthorizationStatus(_ status: Bool) {
+        userDefaults.set(status, forKey: Keys.notificationAuthorizationStatus)
+    }
 
     // MARK: - 작성 뷰 Get
 

--- a/Sodam/Sodam/Model/Manager/UserDefaultsManager.swift
+++ b/Sodam/Sodam/Model/Manager/UserDefaultsManager.swift
@@ -15,33 +15,22 @@ final class UserDefaultsManager {
 
     // 이름 충돌 방지 및 재사용성 증가
     private enum Keys {
-        static let notificationTime = "time"  // 앱 알림 시간
-        static let appSettingToggleState = "appSettingToggleState"  // 앱 설정 토글 상태
+        // MARK: - 작성 뷰
+        
         static let content = "content"  // 작성 내용
         static let imagePath = "imagePath"  // 작성시 등록 이미지
+
+        // MARK: - 설정 뷰
+
+        static let notificationTime = "time"  // 앱 알림 시간
+        static let appSettingToggleState = "appSettingToggleState"  // 앱 설정 토글 상태
         static let notificationAuthorizationStatus = "notificationAuthorizationStatus"  // 알림 권한 상태 (허용/거부)를 UserDefaults에 저장
-        static let toggleSetBeforeKey = "hasUserSetToggleBefore"  // 사용자가 한 번이라도 설정한 적이 있는지 여부 확인
+        static let diaryWrittenTime = "diaryWrittenTime"  // 기록 작성 시간 확인
         static let notificationInitialSetupComplete = "notificationInitialSetupComplete" // 앱 알림 초기 설정 여부 확인
         static let isDiaryWritten = "isDiaryWritten"  // 기록 작성 여부 확인
-        static let diaryWrittenDateKey = "diaryWrittenDateKey"  // 기록 작성 시간
     }
 
-    // MARK: - UserDefaults에 저장
-
-    // 알림 시간을 UserDefaults에 저장
-    func saveNotificationTime(_ time: Date) {
-        userDefaults.set(time, forKey: Keys.notificationTime)
-    }
-
-    // 앱 설정 알림 토글 상태 (ON/OFF)를 UserDefaults에 저장
-    func saveAppNotificationToggleState(_ isOn: Bool) {
-        UserDefaults.standard.set(isOn, forKey: Keys.appSettingToggleState)
-    }
-
-    // 사용자가 한 번이라도 설정한 적이 있는지 여부 반환
-    func hasUserSetToggleBefore() -> Bool {
-        return UserDefaults.standard.bool(forKey: Keys.toggleSetBeforeKey)
-    }
+    // MARK: - 작성 뷰 Save
 
     // 작성된 내용(content)을 UserDefaults에 저장
     func saveContent(_ content: String) {
@@ -53,19 +42,26 @@ final class UserDefaultsManager {
         userDefaults.set(imagePath, forKey: Keys.imagePath)
     }
 
+    // MARK: - Local Notification Save
+    
+    // 알림 시간을 UserDefaults에 저장
+    func saveNotificationTime(_ time: Date) {
+        userDefaults.set(time, forKey: Keys.notificationTime)
+    }
+
+    // 앱 설정 알림 토글 상태 (ON/OFF)를 UserDefaults에 저장
+    func saveAppToggleState(_ isOn: Bool) {
+        UserDefaults.standard.set(isOn, forKey: Keys.appSettingToggleState)
+    }
+    
     // 알림 권한 상태 (허용/거부)를 UserDefaults에 저장
     func saveNotificaionAuthorizationStatus(_ isAuthorized: Bool) {
         userDefaults.set(isAuthorized, forKey: Keys.notificationAuthorizationStatus)
     }
 
     // 일기 작성 여부 저장(알림시간 전 작성된 내용이 있는 경우 확인)
-    func saveDiaryWrittenStatus(_ written: Bool) {
-        UserDefaults.standard.set(written, forKey: Keys.isDiaryWritten)
-    }
-
-    // 일기 작성 날짜 저장
-    func saveDiaryWrittenDate(_ date: Date) {
-        UserDefaults.standard.set(date, forKey: Keys.diaryWrittenDateKey)
+    func saveDiaryWrittenStatus() {
+        UserDefaults.standard.object(forKey: Keys.isDiaryWritten)
     }
 
     // 알림 초기 설정 완료 여부를 확인 (알림 설정이 처음 완료되었는지 여부)
@@ -73,17 +69,7 @@ final class UserDefaultsManager {
         return userDefaults.bool(forKey: Keys.notificationInitialSetupComplete)
     }
 
-    // MARK: - UserDefaults에 저장된 값 얻어오기
-
-    // 저장된 알림 시간을 가져옴
-    func getNotificationTime() -> Date? {
-        userDefaults.object(forKey: Keys.notificationTime) as? Date
-    }
-
-    // 앱 설정 알림 토글 상태 (ON/OFF)를 가져옴
-    func getAppNotificationToggleState() -> Bool {
-        userDefaults.bool(forKey: Keys.appSettingToggleState)
-    }
+    // MARK: - 작성 뷰 Get
 
     // 작성된 내용을 가져옴
     func getContent() -> String? {
@@ -102,14 +88,31 @@ final class UserDefaultsManager {
         userDefaults.removeObject(forKey: Keys.imagePath)
     }
 
+    // MARK: - Local Notification Get
+
+    // 알림 초기 설정을 완료 표시 (true가 완료, false가 미완료)
+    func markNotificationSetupAsComplete() {
+        userDefaults.set(true, forKey: Keys.notificationInitialSetupComplete)
+    }
+
+    // 앱 설정 알림 토글 상태 (ON/OFF)를 가져옴
+    func getAppToggleState() -> Bool {
+        userDefaults.bool(forKey: Keys.appSettingToggleState)
+    }
+
     // 저장된 알림 권한 상태를 가져옴
     func getNotificaionAuthorizationStatus() -> Bool {
         return userDefaults.bool(forKey: Keys.notificationAuthorizationStatus)
     }
 
-    // 저장된 일기 작성 날짜 가져오기
-    func getDiaryWrittenDate() -> Date? {
-        return UserDefaults.standard.value(forKey: Keys.diaryWrittenDateKey) as? Date
+    // 저장된 알림 시간을 가져옴
+    func getNotificationTime() -> Date? {
+        userDefaults.object(forKey: Keys.notificationTime) as? Date
+    }
+
+    // 저장된 일기 작성 시간을 가져옴
+    func getDiaryWrittenTime() -> Date? {
+        return userDefaults.object(forKey: Keys.diaryWrittenTime) as? Date
     }
 
     // 일기 작성 여부 불러오기
@@ -117,18 +120,20 @@ final class UserDefaultsManager {
         return UserDefaults.standard.bool(forKey: Keys.isDiaryWritten)
     }
 
-    // 알림 초기 설정을 완료 표시 (첫 설정 후 완료 상태로 변경)
-    func markNotificationSetupAsComplete() {
-        userDefaults.set(true, forKey: Keys.notificationInitialSetupComplete)
+    // 일기 작성 시간을 저장
+    func markDiaryAsWritten() {
+        let currentDate = Date()
+        UserDefaults.standard.set(currentDate, forKey: Keys.diaryWrittenTime)
+        UserDefaults.standard.set(true, forKey: Keys.isDiaryWritten)
     }
 
-    // 00시에 일기 상태를 재설정
-    func resetDiaryWrittenStatusAtMidnight() {
-        let calendar = Calendar.current
-        let nextMidnight = calendar.startOfDay(for: Date()).addingTimeInterval(24 * 60 * 60)
-
-        Timer.scheduledTimer(withTimeInterval: nextMidnight.timeIntervalSinceNow, repeats: false) { _ in
-            self.saveDiaryWrittenStatus(false)
-        }
+    /// 오늘 작성했다고 UserDefaults에 기록
+    func markAsWrittenToday() {
+        let today = Calendar.current.startOfDay(for: Date())  // 시간을 00:00:00으로 초기화
+        UserDefaults.standard.set(today, forKey: "isDiaryWritten")  // UserDefaults에 오늘 날짜 기록
+        print("오늘 작성 기록 저장됨: \(today)")
+        
+        // 일기 작성 상태와 시간을 UserDefaults에 저장
+        UserDefaultsManager.shared.markDiaryAsWritten()
     }
 }

--- a/Sodam/Sodam/Model/Manager/UserDefaultsManager.swift
+++ b/Sodam/Sodam/Model/Manager/UserDefaultsManager.swift
@@ -16,7 +16,7 @@ final class UserDefaultsManager {
     // 이름 충돌 방지 및 재사용성 증가
     private enum Keys {
         // MARK: - 작성 뷰
-        
+
         static let content = "content"  // 작성 내용
         static let imagePath = "imagePath"  // 작성시 등록 이미지
 
@@ -25,9 +25,9 @@ final class UserDefaultsManager {
         static let notificationTime = "time"  // 앱 알림 시간
         static let appSettingToggleState = "appSettingToggleState"  // 앱 설정 토글 상태
         static let notificationAuthorizationStatus = "notificationAuthorizationStatus"  // 알림 권한 상태 (허용/거부)를 UserDefaults에 저장
-        static let diaryWrittenTime = "diaryWrittenTime"  // 기록 작성 시간 확인
         static let notificationInitialSetupComplete = "notificationInitialSetupComplete" // 앱 알림 초기 설정 여부 확인
-        static let isDiaryWritten = "isDiaryWritten"  // 기록 작성 여부 확인
+        static let diaryWrittenTime = "diaryWrittenTime"  // 기록 작성 시간 확인
+        static let lastWrittenDate = "lastWrittenDate"  // 기록 작성 여부 확인
     }
 
     // MARK: - 작성 뷰 Save
@@ -51,7 +51,7 @@ final class UserDefaultsManager {
 
     // 앱 설정 알림 토글 상태 (ON/OFF)를 UserDefaults에 저장
     func saveAppToggleState(_ isOn: Bool) {
-        UserDefaults.standard.set(isOn, forKey: Keys.appSettingToggleState)
+        userDefaults.set(isOn, forKey: Keys.appSettingToggleState)
     }
     
     // 알림 권한 상태 (허용/거부)를 UserDefaults에 저장
@@ -59,9 +59,13 @@ final class UserDefaultsManager {
         userDefaults.set(isAuthorized, forKey: Keys.notificationAuthorizationStatus)
     }
 
-    // 일기 작성 여부 저장(알림시간 전 작성된 내용이 있는 경우 확인)
-    func saveDiaryWrittenStatus() {
-        UserDefaults.standard.object(forKey: Keys.isDiaryWritten)
+    // 오늘 작성했는지 확인하는 메서드
+    func hasAlreadyWrittenToday() -> Bool {
+        guard let lastWrittenTimestamp = userDefaults.object(forKey: Keys.lastWrittenDate) as? TimeInterval else {
+            return false
+        }
+        let lastWrittenDate = Date(timeIntervalSince1970: lastWrittenTimestamp)
+        return Calendar.current.isDateInToday(lastWrittenDate)
     }
 
     // 알림 초기 설정 완료 여부를 확인 (알림 설정이 처음 완료되었는지 여부)
@@ -110,30 +114,20 @@ final class UserDefaultsManager {
         userDefaults.object(forKey: Keys.notificationTime) as? Date
     }
 
-    // 저장된 일기 작성 시간을 가져옴
-    func getDiaryWrittenTime() -> Date? {
-        return userDefaults.object(forKey: Keys.diaryWrittenTime) as? Date
-    }
-
-    // 일기 작성 여부 불러오기
-    func getDiaryWrittenStatus() -> Bool {
-        return UserDefaults.standard.bool(forKey: Keys.isDiaryWritten)
-    }
-
-    // 일기 작성 시간을 저장
-    func markDiaryAsWritten() {
-        let currentDate = Date()
-        UserDefaults.standard.set(currentDate, forKey: Keys.diaryWrittenTime)
-        UserDefaults.standard.set(true, forKey: Keys.isDiaryWritten)
-    }
-
-    /// 오늘 작성했다고 UserDefaults에 기록
+    // 오늘 작성했다고 UserDefaults에 저장 (시간 포함)
     func markAsWrittenToday() {
-        let today = Calendar.current.startOfDay(for: Date())  // 시간을 00:00:00으로 초기화
-        UserDefaults.standard.set(today, forKey: "isDiaryWritten")  // UserDefaults에 오늘 날짜 기록
-        print("오늘 작성 기록 저장됨: \(today)")
+        let now = Date() // 현재 시간 저장
+        let todayStart = Calendar.current.startOfDay(for: now) // 날짜만 저장 (00:00:00)
         
-        // 일기 작성 상태와 시간을 UserDefaults에 저장
-        UserDefaultsManager.shared.markDiaryAsWritten()
+        userDefaults.set(todayStart.timeIntervalSince1970, forKey: Keys.lastWrittenDate) // 날짜만 저장
+        userDefaults.set(now.timeIntervalSince1970, forKey: Keys.diaryWrittenTime) // 정확한 작성 시간 저장
+    }
+    
+    // 저장된 일기 작성 시간 가져오기
+    func getDiaryWrittenTime() -> Date? {
+        guard let timestamp = userDefaults.object(forKey: Keys.diaryWrittenTime) as? TimeInterval else {
+            return nil
+        }
+        return Date(timeIntervalSince1970: timestamp)
     }
 }

--- a/Sodam/Sodam/Model/Manager/UserDefaultsManager.swift
+++ b/Sodam/Sodam/Model/Manager/UserDefaultsManager.swift
@@ -26,7 +26,6 @@ final class UserDefaultsManager {
         static let appSettingToggleState = "appSettingToggleState"  // 앱 설정 토글 상태
         static let notificationAuthorizationStatus = "notificationAuthorizationStatus"  // 알림 권한 상태 (허용/거부)를 UserDefaults에 저장
         static let notificationInitialSetupComplete = "notificationInitialSetupComplete" // 앱 알림 초기 설정 여부 확인
-        static let diaryWrittenTime = "diaryWrittenTime"  // 기록 작성 시간 확인
         static let lastWrittenDate = "lastWrittenDate"  // 기록 작성 여부 확인
     }
 
@@ -59,13 +58,11 @@ final class UserDefaultsManager {
         userDefaults.set(isAuthorized, forKey: Keys.notificationAuthorizationStatus)
     }
 
-    // 오늘 작성했는지 확인하는 메서드
+    // 오늘 일기 작성했는지 확인하는 메서드
     func hasAlreadyWrittenToday() -> Bool {
-        guard let lastWrittenTimestamp = userDefaults.object(forKey: Keys.lastWrittenDate) as? TimeInterval else {
-            return false
-        }
-        let lastWrittenDate = Date(timeIntervalSince1970: lastWrittenTimestamp)
-        return Calendar.current.isDateInToday(lastWrittenDate)
+        let lastWrittenDate = UserDefaults.standard.object(forKey: "lastWrittenDate") as? Date ?? Date.distantPast
+        let calendar = Calendar.current
+        return calendar.isDateInToday(lastWrittenDate)
     }
 
     // 알림 초기 설정 완료 여부를 확인 (알림 설정이 처음 완료되었는지 여부)
@@ -116,18 +113,7 @@ final class UserDefaultsManager {
 
     // 오늘 작성했다고 UserDefaults에 저장 (시간 포함)
     func markAsWrittenToday() {
-        let now = Date() // 현재 시간 저장
-        let todayStart = Calendar.current.startOfDay(for: now) // 날짜만 저장 (00:00:00)
-        
-        userDefaults.set(todayStart.timeIntervalSince1970, forKey: Keys.lastWrittenDate) // 날짜만 저장
-        userDefaults.set(now.timeIntervalSince1970, forKey: Keys.diaryWrittenTime) // 정확한 작성 시간 저장
-    }
-    
-    // 저장된 일기 작성 시간 가져오기
-    func getDiaryWrittenTime() -> Date? {
-        guard let timestamp = userDefaults.object(forKey: Keys.diaryWrittenTime) as? TimeInterval else {
-            return nil
-        }
-        return Date(timeIntervalSince1970: timestamp)
+        let today = Calendar.current.startOfDay(for: Date())  // 시간을 00:00:00으로 초기화
+        UserDefaults.standard.set(today, forKey: "lastWrittenDate") // UserDefaults에 저장
     }
 }

--- a/Sodam/Sodam/View/Main/MainView/MainViewController.swift
+++ b/Sodam/Sodam/View/Main/MainView/MainViewController.swift
@@ -50,7 +50,7 @@ final class MainViewController: UIViewController {
     override func viewWillAppear (_ animated: Bool) {
         viewModel.reloadHangdam() // ViewModel에서 행담이 데이터를 갱신
         updateButtonState()       // 화면이 다시 나타날 때 버튼 상태 갱신
-        LocalNotificationManager.shared.checkInitialSetup()  // 앱 첫 진입시 알림 권한 팝업 설정
+        viewModel.checkNotificationAuthorization() // MainView 진입 시 알림 권한 체크 설정
     }
 
     // MARK: - bind view model for update view

--- a/Sodam/Sodam/View/Main/MainView/MainViewModel.swift
+++ b/Sodam/Sodam/View/Main/MainView/MainViewModel.swift
@@ -66,16 +66,12 @@ final class MainViewModel: ObservableObject {
 
     /// 오늘 작성했는지 확인하는 메서드
     func hasAlreadyWrittenToday() -> Bool {
-        let lastWrittenDate = UserDefaults.standard.object(forKey: "lastWrittenDate") as? Date ?? Date.distantPast
-        let calendar = Calendar.current
-        return calendar.isDateInToday(lastWrittenDate) // UserDefaults에서 읽어옴
+        UserDefaultsManager.shared.hasAlreadyWrittenToday()
     }
 
     /// 오늘 작성했다고 UserDefaults에 lastWrittenDate라는 키로 저장
     func markAsWrittenToday() {
-        let today = Calendar.current.startOfDay(for: Date())  // 시간을 00:00:00으로 초기화
-        UserDefaults.standard.set(today, forKey: "lastWrittenDate") // UserDefaults에 저장
-        print("오늘 작성 기록 저장됨: \(today)")
+        UserDefaultsManager.shared.markAsWrittenToday()
     }
 
     /// 행담이가 레벨업 할 때 메세지를 업데이트 함

--- a/Sodam/Sodam/View/Main/MainView/MainViewModel.swift
+++ b/Sodam/Sodam/View/Main/MainView/MainViewModel.swift
@@ -55,6 +55,13 @@ final class MainViewModel: ObservableObject {
         self.hangdam = hangdamRepository.getCurrentHangdam()
     }
 
+    /// LocalNotificationManager 접근하여 알림 권한 체크 설정
+    func checkNotificationAuthorization() {
+        LocalNotificationManager.shared.checkAuthorization { [weak self] _ in
+            guard self != nil else { return }
+        }
+    }
+
     // MARK: - TodayWriteUserDefaults(테스트 하는 동안 주석처리)
 
     /// 오늘 작성했는지 확인하는 메서드

--- a/Sodam/Sodam/View/Main/WriteView/WriteViewModel.swift
+++ b/Sodam/Sodam/View/Main/WriteView/WriteViewModel.swift
@@ -70,9 +70,6 @@ extension WriteViewModel {
 
         // 작성 완료 알림 표시 후 모달 닫기
         completion()
-        
-        // 오늘 작성했다고 기록
-        UserDefaultsManager.shared.markAsWrittenToday()
     }
 
     /// 작성 취소 이벤트 처리 메서드

--- a/Sodam/Sodam/View/Main/WriteView/WriteViewModel.swift
+++ b/Sodam/Sodam/View/Main/WriteView/WriteViewModel.swift
@@ -63,7 +63,6 @@ extension WriteViewModel {
         happinessRepository.createHappiness(newHappiness)
 
         isPostSubmitted = true
-        UserDefaultsManager.shared.saveDiaryWrittenStatus(true)
 
         // post 초기화
         resetPost()
@@ -71,6 +70,9 @@ extension WriteViewModel {
 
         // 작성 완료 알림 표시 후 모달 닫기
         completion()
+        
+        // 오늘 작성했다고 기록
+        UserDefaultsManager.shared.markAsWrittenToday()
     }
 
     /// 작성 취소 이벤트 처리 메서드

--- a/Sodam/Sodam/View/Setting/SettingTableViewCell.swift
+++ b/Sodam/Sodam/View/Setting/SettingTableViewCell.swift
@@ -31,7 +31,7 @@ final class SettingTableViewCell: UITableViewCell, ReuseIdentifying {
         timePicker.preferredDatePickerStyle = .compact
         timePicker.datePickerMode = .time
         timePicker.locale = Locale(identifier: "ko")
-        timePicker.minuteInterval = 30
+        timePicker.minuteInterval = 1
         timePicker.tintColor = .buttonBackground
         return timePicker
     }()

--- a/Sodam/Sodam/View/Setting/SettingTableViewCell.swift
+++ b/Sodam/Sodam/View/Setting/SettingTableViewCell.swift
@@ -31,7 +31,7 @@ final class SettingTableViewCell: UITableViewCell, ReuseIdentifying {
         timePicker.preferredDatePickerStyle = .compact
         timePicker.datePickerMode = .time
         timePicker.locale = Locale(identifier: "ko")
-        timePicker.minuteInterval = 1
+        timePicker.minuteInterval = 30
         timePicker.tintColor = .buttonBackground
         return timePicker
     }()

--- a/Sodam/Sodam/View/Setting/SettingViewModel.swift
+++ b/Sodam/Sodam/View/Setting/SettingViewModel.swift
@@ -115,14 +115,7 @@ extension SettingViewModel {
 // MARK: - LocalNotificationManger Methods
 
 extension SettingViewModel {
-    // 최근 요청한 알림 권한 상태 가져오기
-    func requestNotificationStatus(completion: @escaping (Bool) -> Void) {
-        localNotificationManager.requestAuthorization { status in
-            completion(status)
-        }
-    }
-    
-    // 실시간 알림 권한 상태 가져오기
+    // 요청한 알림 권한 상태 가져오기
     func checkNotificationStatus(completion: @escaping (Bool) -> Void) {
         localNotificationManager.checkAuthorization { status in
             completion(status)

--- a/Sodam/Sodam/View/Setting/SettingViewModel.swift
+++ b/Sodam/Sodam/View/Setting/SettingViewModel.swift
@@ -74,7 +74,7 @@ extension SettingViewModel {
     
     // 사용자가 설정한 예약된 알림 설정
     func setUserNotification(_ sender: Date) {
-        localNotificationManager.setUserNotification(time: sender, showToast: false)
+        localNotificationManager.setUserNotification(time: sender)
     }
 }
 

--- a/Sodam/Sodam/View/Setting/SettingViewModel.swift
+++ b/Sodam/Sodam/View/Setting/SettingViewModel.swift
@@ -52,13 +52,13 @@ extension SettingViewModel {
         )
         
         let cancelAction = UIAlertAction(title: "취소", style: .cancel) { [weak self] _ in
-            guard let self = self else {
+            guard self != nil else {
                 return
             }
         }
         
         let settingsAction = UIAlertAction(title: "설정으로 이동", style: .default) { [weak self] _ in
-            guard let self = self else {
+            guard self != nil else {
                 return
             }
             if let url = URL(string: UIApplication.openSettingsURLString),
@@ -107,8 +107,8 @@ extension SettingViewModel {
     }
     
     // 사용자가 설정한 예약된 알림 설정
-    func setReservedNotificaion(_ sender: Date) {
-        localNotificationManager.setReservedNotification(sender)
+    func setUserNotification(_ sender: Date) {
+        localNotificationManager.setUserNotification(time: sender, showToast: false)
     }
 }
 

--- a/Sodam/Sodam/View/Setting/SettingViewModel.swift
+++ b/Sodam/Sodam/View/Setting/SettingViewModel.swift
@@ -42,36 +42,6 @@ extension SettingViewModel {
         }
         UIApplication.shared.open(url, options: [:], completionHandler: nil)
     }
-    
-    // 시스템 설정 거부 상태시 토글 on 할때 시스템 설정으로 이동을 요청 팝업
-    func showNotificationPermissionAlert(viewController: UIViewController) {
-        let alertController = UIAlertController(
-            title: "알림 권한 필요",
-            message: "앱의 알림을 받으려면 설정에서 알림을 허용해주세요.",
-            preferredStyle: .alert
-        )
-        
-        let cancelAction = UIAlertAction(title: "취소", style: .cancel) { [weak self] _ in
-            guard self != nil else {
-                return
-            }
-        }
-        
-        let settingsAction = UIAlertAction(title: "설정으로 이동", style: .default) { [weak self] _ in
-            guard self != nil else {
-                return
-            }
-            if let url = URL(string: UIApplication.openSettingsURLString),
-               UIApplication.shared.canOpenURL(url) {
-                UIApplication.shared.open(url, options: [:])
-            }
-        }
-        
-        alertController.addAction(cancelAction)
-        alertController.addAction(settingsAction)
-        
-        viewController.present(alertController, animated: true)
-    }
 }
 
 // MARK: - UserDefaultsManager Methods

--- a/Sodam/Sodam/View/Setting/SettingViewModel.swift
+++ b/Sodam/Sodam/View/Setting/SettingViewModel.swift
@@ -60,10 +60,6 @@ extension SettingViewModel {
         userDefaultsManager.saveAppToggleState(isOn)
     }
     
-    func saveNotificationAuthorizationStatus(_ status: Bool) {
-        userDefaultsManager.saveNotificaionAuthorizationStatus(status)
-    }
-    
     // MARK: - Get Methods
     
     // 저장된 알림 시간 가져오기

--- a/Sodam/Sodam/View/Setting/SettingViewModel.swift
+++ b/Sodam/Sodam/View/Setting/SettingViewModel.swift
@@ -11,64 +11,121 @@ final class SettingViewModel {
     private let userDefaultsManager = UserDefaultsManager.shared
     private let localNotificationManager = LocalNotificationManager.shared
 
-    var isToggleOn: Bool  // 앱 설정 알림 토글 상ㅌ
-
-    let sectionType: [Setting.SetSection] = [.appSetting, .develop]  // 섹션 타입 설정
+    var isToggleOn: Bool   // 앱 설정 토글 상태
+    let sectionType: [Setting.SetSection] = [.appSetting, .develop]   // 섹션 타입 설정
+    
     // 앱 버전을 가져오는 computed property
     var version: String? {
         guard let dictionary = Bundle.main.infoDictionary,
               let version = dictionary["CFBundleShortVersionString"] as? String else {
             return nil
         }
-
+        
         let versionString: String = "\(version)"
         return versionString
     }
-
+    
     // MARK: - Initializer
+    
     init() {
-        self.isToggleOn = userDefaultsManager.getAppNotificationToggleState()
+        self.isToggleOn = userDefaultsManager.getAppToggleState()  // 앱 토글 상태 가져와서 isTogglOn 초기화
     }
+}
 
-    // 알림 시간 저장
-    func saveNotificationTime(_ sender: Date) {
-        userDefaultsManager.saveNotificationTime(sender)
-    }
+// MARK: - SettingViewController Methods
 
-    // 앱 설정 알림 토글 상태 저장
-    func saveIsAppToggleNotification(_ sender: Bool) {
-        userDefaultsManager.saveAppNotificationToggleState(sender)
-    }
-
-    // 사용자가 한 번이라도 설정한 적이 있는지 여부 반환
-    func hasUserSetToggleBefore() -> Bool {
-        userDefaultsManager.hasUserSetToggleBefore()
-    }
-
-    func saveNotificationAuthorizationStatus(_ status: Bool) {
-        userDefaultsManager.saveNotificaionAuthorizationStatus(status)
-    }
-
-    // 저장된 알림 시간 가져오기
-    func getNotificationTime() -> Date? {
-        userDefaultsManager.getNotificationTime()
-    }
-
-    // 알림 토글 상태 가져오기
-    func getAppNotificationToggleState() -> Bool {
-        userDefaultsManager.getAppNotificationToggleState()
-    }
-
-    // 사용자가 설정한 예약된 알림 설정
-    func setReservedNotificaion(_ sender: Date) {
-        localNotificationManager.setReservedNotification(sender)
-    }
-
-    // URL 열기 메서드
+extension SettingViewModel {
+    // URL 새창에서 메서드
     func openURL(_ urlString: String) {
         guard let url = URL(string: urlString), UIApplication.shared.canOpenURL(url) else {
             return
         }
         UIApplication.shared.open(url, options: [:], completionHandler: nil)
+    }
+    
+    // 시스템 설정 거부 상태시 토글 on 할때 시스템 설정으로 이동을 요청 팝업
+    func showNotificationPermissionAlert(viewController: UIViewController) {
+        let alertController = UIAlertController(
+            title: "알림 권한 필요",
+            message: "앱의 알림을 받으려면 설정에서 알림을 허용해주세요.",
+            preferredStyle: .alert
+        )
+        
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel) { [weak self] _ in
+            guard let self = self else {
+                return
+            }
+        }
+        
+        let settingsAction = UIAlertAction(title: "설정으로 이동", style: .default) { [weak self] _ in
+            guard let self = self else {
+                return
+            }
+            if let url = URL(string: UIApplication.openSettingsURLString),
+               UIApplication.shared.canOpenURL(url) {
+                UIApplication.shared.open(url, options: [:])
+            }
+        }
+        
+        alertController.addAction(cancelAction)
+        alertController.addAction(settingsAction)
+        
+        viewController.present(alertController, animated: true)
+    }
+}
+
+// MARK: - UserDefaultsManager Methods
+
+extension SettingViewModel {
+    
+    // MARK: - Save Methods
+    
+    // 알림 시간 저장
+    func saveNotificationTime(_ time: Date) {
+        userDefaultsManager.saveNotificationTime(time)
+    }
+    
+    // 앱 설정 알림 토글 상태 저장
+    func saveAppToggleState(_ isOn: Bool) {
+        userDefaultsManager.saveAppToggleState(isOn)
+    }
+    
+    func saveNotificationAuthorizationStatus(_ status: Bool) {
+        userDefaultsManager.saveNotificaionAuthorizationStatus(status)
+    }
+    
+    // MARK: - Get Methods
+    
+    // 저장된 알림 시간 가져오기
+    func getNotificationTime() -> Date? {
+        userDefaultsManager.getNotificationTime()
+    }
+    
+    // 앱 토글 상태 가져오기
+    func getToggleState() -> Bool {
+        userDefaultsManager.getAppToggleState()
+    }
+    
+    // 사용자가 설정한 예약된 알림 설정
+    func setReservedNotificaion(_ sender: Date) {
+        localNotificationManager.setReservedNotification(sender)
+    }
+}
+
+// MARK: - LocalNotificationManger Methods
+
+extension SettingViewModel {
+    // 최근 요청한 알림 권한 상태 가져오기
+    func requestNotificationStatus(completion: @escaping (Bool) -> Void) {
+        localNotificationManager.requestAuthorization { status in
+            completion(status)
+        }
+    }
+    
+    // 실시간 알림 권한 상태 가져오기
+    func checkNotificationStatus(completion: @escaping (Bool) -> Void) {
+        localNotificationManager.checkAuthorization { status in
+            completion(status)
+        }
     }
 }

--- a/Sodam/Sodam/View/Setting/SettingsViewController.swift
+++ b/Sodam/Sodam/View/Setting/SettingsViewController.swift
@@ -64,11 +64,6 @@ private extension SettingsViewController {
         settingView.tableView.register(SettingTableViewCell.self, forCellReuseIdentifier: SettingTableViewCell.reuseIdentifier)
     }
 
-    // BadgeNumber Init
-    func initBadgeNumber() {
-        UIApplication.shared.applicationIconBadgeNumber = 0  // 사용자 설정 화면에 진입할 때 뱃지 초기화
-    }
-
     // NotificationCenter Observer Set
     func setupObservers() {
         NotificationCenter.default.addObserver(self,

--- a/Sodam/Sodam/View/Setting/SettingsViewController.swift
+++ b/Sodam/Sodam/View/Setting/SettingsViewController.swift
@@ -35,7 +35,7 @@ final class SettingsViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         setupObservers()
-        setupChekNotification()
+        setupCheckNotification()
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -83,7 +83,7 @@ private extension SettingsViewController {
     }
 
     // Check Notification Set
-        func setupChekNotification() {
+        func setupCheckNotification() {
             UIApplication.shared.applicationIconBadgeNumber = 0  // 사용자 설정 화면에 진입할 때 뱃지 초기화
             checkNotificationStatus()  // 뷰가 나타날 때마다 현재 알림 권한 상태를 체크하고 UI 업데이트
         }

--- a/Sodam/Sodam/View/Setting/SettingsViewController.swift
+++ b/Sodam/Sodam/View/Setting/SettingsViewController.swift
@@ -70,7 +70,7 @@ private extension SettingsViewController {
     // NotificationCenter Observer Set
     func setupObservers() {
         NotificationCenter.default.addObserver(self,
-                                               selector: #selector(updateNotificationStatus),
+                                               selector: #selector(checkNotificationStatus),
                                                name: UIApplication.willEnterForegroundNotification,
                                                object: nil)
     }
@@ -85,11 +85,11 @@ private extension SettingsViewController {
     // Check Notification Set
         func setupChekNotification() {
             UIApplication.shared.applicationIconBadgeNumber = 0  // 사용자 설정 화면에 진입할 때 뱃지 초기화
-            updateNotificationStatus()  // 뷰가 나타날 때마다 현재 알림 권한 상태를 체크하고 UI 업데이트
+            checkNotificationStatus()  // 뷰가 나타날 때마다 현재 알림 권한 상태를 체크하고 UI 업데이트
         }
 
     // NotificationStatus Check
-    @objc func updateNotificationStatus() {
+    @objc func checkNotificationStatus() {
         settingViewModel.checkNotificationStatus { [weak self] isAuthorized in
             guard let self = self else { return }
             DispatchQueue.main.async {
@@ -223,7 +223,7 @@ extension SettingsViewController: UITableViewDataSource, UITableViewDelegate {
     // 알림 스위치의 상태가 변경되었을 때 호출되는 액션
     @objc func didToggleSwitch(_ sender: UISwitch) {
         let toggleState = sender.isOn
-        settingViewModel.requestNotificationStatus { [weak self] status in
+        settingViewModel.checkNotificationStatus { [weak self] status in
             guard let self = self else { return }
             DispatchQueue.main.async {
                 // 시스템 설정 확인 후 허용시,

--- a/Sodam/Sodam/View/Setting/SettingsViewController.swift
+++ b/Sodam/Sodam/View/Setting/SettingsViewController.swift
@@ -235,7 +235,7 @@ extension SettingsViewController: UITableViewDataSource, UITableViewDelegate {
                         
                         // 알림 예약을 다시 설정 (스위치가 켜졌을 때만)
                         if let notificationTime = self.settingViewModel.getNotificationTime() {
-                            self.settingViewModel.setReservedNotificaion(notificationTime)
+                            self.settingViewModel.setUserNotification(notificationTime)
                         }
                         
                     } else {
@@ -264,7 +264,7 @@ extension SettingsViewController: UITableViewDataSource, UITableViewDelegate {
         settingViewModel.saveNotificationTime(sender.date)
         
         if settingViewModel.isToggleOn {
-            settingViewModel.setReservedNotificaion(sender.date)
+            settingViewModel.setUserNotification(sender.date)
         }
     }
 }


### PR DESCRIPTION
## 1. 요약 
- 일기 작성이 된 경우 알림시간이 설정되어있어도 알림 X (하루기준) 앱실행, 포그라운드, 백그라운드 모두 적용완료
- 다음날 일기 작성이 안된 경우 사용자가 마지막 설정한 알림시간이 있다면 알림 O 앱실행, 포그라운드, 백그라운드 모두 적용완료

- [LocalNotificationManger 리팩토링](https://github.com/Sodamii/Sodam/commit/aba7d8ec86ca916baec9d89e099415c8ceb29022)

## 2. 스크린샷 

## 3. 공유사항
1. MainViewModel 기존 코드 UserDefaultManager로 수정 (이미지상 오류는 무시하셔도됩니다! pr 올리고 캡쳐해서 나오는 오류입니다.)
<img width="753" alt="스크린샷 2025-02-19 오후 12 57 53" src="https://github.com/user-attachments/assets/d9f2634a-5957-41c0-ad01-073d3d7f0909" />

2. 지혜님이 달아주신 리뷰도 수정완료하였습니다!

