### PR TITLE
[Refactor] 코어데이터 및 레포지토리 비동기 처리

### DIFF
--- a/Sodam/Sodam/Extension/+Result+Fold.swift
+++ b/Sodam/Sodam/Extension/+Result+Fold.swift
@@ -14,4 +14,13 @@ extension Result {
             return try onFailure(error)
         }
     }
+    
+    func asyncFold<T>(onSuccess: (Success) async throws-> T, onFailure: (Failure) async throws -> T) async rethrows -> T {
+        switch self {
+        case .success(let value):
+            return try await onSuccess(value)
+        case .failure(let error):
+            return try await onFailure(error)
+        }
+    }
 }

--- a/Sodam/Sodam/Extension/+Result+Fold.swift
+++ b/Sodam/Sodam/Extension/+Result+Fold.swift
@@ -6,12 +6,12 @@
 //
 
 extension Result {
-    func fold<T>(onSuccess: (Success) -> T, onFailure: (Failure) -> T) -> T {
+    func fold<T>(onSuccess: (Success) throws-> T, onFailure: (Failure) throws -> T) rethrows -> T {
         switch self {
         case .success(let value):
-            return onSuccess(value)
+            return try onSuccess(value)
         case .failure(let error):
-            return onFailure(error)
+            return try onFailure(error)
         }
     }
 }

--- a/Sodam/Sodam/Model/DTO/DTOMapper.swift
+++ b/Sodam/Sodam/Model/DTO/DTOMapper.swift
@@ -20,7 +20,7 @@ struct HangdamMapper {
     }
 }
 
-struct HappinessMapper {
+struct HappinessMapper { // DTO <> Enitity 양방향으로 변환 시켜주니 Converter라는 이름도 잘 맞을 듯
     func toDTO(from entity: HappinessEntity) -> HappinessDTO? {
         guard let content = entity.content,
               let date = entity.date,

--- a/Sodam/Sodam/Model/Error/DataError.swift
+++ b/Sodam/Sodam/Model/Error/DataError.swift
@@ -16,6 +16,7 @@ enum DataError: Error {
     case convertImagePathsFailed
     case deleteEnitityFailed
     case backgroundTaskFailed
+    case selfIsNil
 
     // 디버깅용 print 구문
     var localizedDescription: String {
@@ -28,6 +29,7 @@ enum DataError: Error {
         case .convertImagePathsFailed: "[CoreData Error] DTO [String] >>> Data 변환 실패"
         case .deleteEnitityFailed: "[CoreData Error] enitity 삭제 실패"
         case .backgroundTaskFailed: "[CoreData Error] background task 메서드 실패"
+        case .selfIsNil: "[CoreData Error] self가 없음"
         }
     }
 

--- a/Sodam/Sodam/Model/Error/DataError.swift
+++ b/Sodam/Sodam/Model/Error/DataError.swift
@@ -14,6 +14,8 @@ enum DataError: Error {
     case searchEntityFailed
     case convertIDFailed
     case convertImagePathsFailed
+    case deleteEnitityFailed
+    case backgroundTaskFailed
 
     // 디버깅용 print 구문
     var localizedDescription: String {
@@ -24,6 +26,8 @@ enum DataError: Error {
         case .searchEntityFailed: "[CoreData Error] entity search 실패"
         case .convertIDFailed: "[CoreData Error] DTO id >>> NSManagedObjectID 변환 실패"
         case .convertImagePathsFailed: "[CoreData Error] DTO [String] >>> Data 변환 실패"
+        case .deleteEnitityFailed: "[CoreData Error] enitity 삭제 실패"
+        case .backgroundTaskFailed: "[CoreData Error] background task 메서드 실패"
         }
     }
 
@@ -33,7 +37,7 @@ enum DataError: Error {
         case .containerLoadFailed: "오류로 인해 행담이를 불러오지 못했어요🥲\n앱 종료 후 재실행하거나, 개발자에게 문의해주세요."
         case .contextSaveFailed: "변경 사항 저장에 실패했어요🥲\n 다시 시도하거나, 개발자에게 문의해주세요."
         case .fetchRequestFailed: "데이터를 불러오는 데 실패했어요🥲\n앱 종료 후 재실행하거나, 개발자에게 문의해주세요."
-        case .searchEntityFailed, .convertIDFailed, .convertImagePathsFailed: "작업에 실패했어요🥲"
+        default: "작업에 실패했어요🥲"
         }
     }
 }

--- a/Sodam/Sodam/Model/Manager/CoreDataManager + Extension.swift
+++ b/Sodam/Sodam/Model/Manager/CoreDataManager + Extension.swift
@@ -62,10 +62,13 @@ extension CoreDataManager {
         }
     }
     
-    func deleteEntityByIdAsync<T: NSManagedObject>(id: NSManagedObjectID, type: T.Type, context: NSManagedObjectContext) async throws {
+    func deleteEntityByIdAsync<T: NSManagedObject>(id: String?, type: T.Type, context: NSManagedObjectContext) async throws {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             context.perform {
-                guard let entity = context.object(with: id) as? T else {
+                guard let _id: NSManagedObjectID = IDConverter.toNSManagedObjectID(from: id, in: context) else {
+                    return continuation.resume(throwing: DataError.convertIDFailed)
+                }
+                guard let entity = context.object(with: _id) as? T else {
                     return continuation.resume(throwing: DataError.deleteEnitityFailed)
                 }
                 

--- a/Sodam/Sodam/Model/Manager/CoreDataManager + Extension.swift
+++ b/Sodam/Sodam/Model/Manager/CoreDataManager + Extension.swift
@@ -1,0 +1,100 @@
+//
+//  CoreDataManager + Extension.swift
+//  Sodam
+//
+//  Created by 박진홍 on 2/19/25.
+//
+
+// 추상화되고 비동기적으로 동작하는 메서드 추가
+
+import CoreData
+
+extension CoreDataManager {
+
+    func createEntityAsync<T: NSManagedObject>(type: T.Type) async throws-> T {
+        try await withCheckedThrowingContinuation { continuation in
+            persistentContainer.performBackgroundTask { context in
+                context.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+                let newEntity = T(context: context)
+                do {
+                    try context.save()
+                    continuation.resume(returning: newEntity)
+                } catch {
+                    continuation.resume(throwing: DataError.contextSaveFailed)
+                }
+            }
+        }
+    }
+
+    func fetchEntityByIdAsync<T: NSManagedObject>(id: NSManagedObjectID) async throws -> T {
+        try await withCheckedThrowingContinuation { continuation in
+            persistentContainer.performBackgroundTask { context in
+                context.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+                guard let entity = context.object(with: id) as? T else {
+                    return continuation.resume(throwing: DataError.fetchRequestFailed)
+                }
+                continuation.resume(returning: entity)
+            }
+        }
+    }
+
+    func fetchEntitiesAsync<T: NSManagedObject>(
+        entityType type: T.Type,
+        predicate: NSPredicate? = nil,
+        sortDescriptors: [NSSortDescriptor]? = nil
+    ) async throws -> [T] {
+        try await withCheckedThrowingContinuation { continuation in
+            persistentContainer.performBackgroundTask { context in
+                context.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+                let entityName: String = String(describing: type)
+                let fetchRequest: NSFetchRequest<T> = NSFetchRequest<T>(entityName: entityName)
+                fetchRequest.predicate = predicate
+                fetchRequest.sortDescriptors = sortDescriptors
+                
+                do {
+                    let entities: [T] = try context.fetch(fetchRequest)
+                    continuation.resume(returning: entities)
+                } catch {
+                    continuation.resume(throwing: DataError.fetchRequestFailed)
+                }
+            }
+        }
+    }
+
+    func deleteEntityByIdAsync<T: NSManagedObject>(id: NSManagedObjectID, type: T.Type) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            persistentContainer.performBackgroundTask { context in
+                context.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+                guard let entity = context.object(with: id) as? T else {
+                    return continuation.resume(throwing: DataError.deleteEnitityFailed)
+                }
+                
+                do {
+                    context.delete(entity)
+                    try context.save()
+                    continuation.resume(returning: ())
+                } catch {
+                    continuation.resume(throwing: DataError.deleteEnitityFailed)
+                }
+            }
+        }
+    }
+
+    func performBackgroundTaskAsync<T>(operation: @escaping (NSManagedObjectContext) throws -> T) async throws -> T {
+        try await withCheckedThrowingContinuation { continuation in
+            persistentContainer.performBackgroundTask { context in
+                context.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+                do {
+                    let result = try operation(context)
+                    if context.hasChanges {
+                        try context.save()
+                    }
+                    
+                    continuation.resume(returning: result)
+                } catch {
+                    continuation.resume(throwing: DataError.backgroundTaskFailed)
+                }
+            }
+        }
+    }
+}

--- a/Sodam/Sodam/Model/Manager/CoreDataManager + Extension.swift
+++ b/Sodam/Sodam/Model/Manager/CoreDataManager + Extension.swift
@@ -11,7 +11,7 @@ import CoreData
 
 extension CoreDataManager {
 
-    func createEntityAsync<T: NSManagedObject>(type: T.Type, context: NSManagedObjectContext) async throws -> T {
+    func createEntityAsync<T: NSManagedObject>(context: NSManagedObjectContext) async throws -> T {
         try await withCheckedThrowingContinuation { continuation in
             context.perform {
                 let newEntity = T(context: context)
@@ -40,14 +40,13 @@ extension CoreDataManager {
     }
 
     func fetchEntitiesAsync<T: NSManagedObject>(
-        entityType type: T.Type,
         context: NSManagedObjectContext,
         predicate: NSPredicate? = nil,
         sortDescriptors: [NSSortDescriptor]? = nil
     ) async throws -> [T] {
         try await withCheckedThrowingContinuation { continuation in
             context.perform {
-                let entityName: String = String(describing: type)
+                let entityName: String = String(describing: T.self)
                 let fetchRequest: NSFetchRequest<T> = NSFetchRequest<T>(entityName: entityName)
                 fetchRequest.predicate = predicate
                 fetchRequest.sortDescriptors = sortDescriptors

--- a/Sodam/Sodam/Model/Manager/CoreDataManager + Extension.swift
+++ b/Sodam/Sodam/Model/Manager/CoreDataManager + Extension.swift
@@ -26,11 +26,14 @@ extension CoreDataManager {
         }
     }
 
-    func fetchEntityByIdAsync<T: NSManagedObject>(id: NSManagedObjectID) async throws -> T {
+    func fetchEntityByIdAsync<T: NSManagedObject>(id: String?) async throws -> T {
         try await withCheckedThrowingContinuation { continuation in
             persistentContainer.performBackgroundTask { context in
+                guard let _id: NSManagedObjectID = IDConverter.toNSManagedObjectID(from: id, in: context) else {
+                    return continuation.resume(throwing: DataError.convertIDFailed)
+                }
                 context.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
-                guard let entity = context.object(with: id) as? T else {
+                guard let entity = context.object(with: _id) as? T else {
                     return continuation.resume(throwing: DataError.fetchRequestFailed)
                 }
                 continuation.resume(returning: entity)

--- a/Sodam/Sodam/Model/Manager/CoreDataManager + Extension.swift
+++ b/Sodam/Sodam/Model/Manager/CoreDataManager + Extension.swift
@@ -31,7 +31,6 @@ extension CoreDataManager {
                 guard let _id: NSManagedObjectID = IDConverter.toNSManagedObjectID(from: id, in: context) else {
                     return continuation.resume(throwing: DataError.convertIDFailed)
                 }
-                context.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
                 guard let entity = context.object(with: _id) as? T else {
                     return continuation.resume(throwing: DataError.fetchRequestFailed)
                 }

--- a/Sodam/Sodam/Model/Manager/CoreDataManager.swift
+++ b/Sodam/Sodam/Model/Manager/CoreDataManager.swift
@@ -11,7 +11,7 @@ import CoreData
 
 final class CoreDataManager {
     static let shared = CoreDataManager()
-    private let persistentContainer: NSPersistentContainer
+    let persistentContainer: NSPersistentContainer
 
     private init() {
         persistentContainer = NSPersistentContainer(name: CDKey.container.rawValue)
@@ -23,6 +23,8 @@ final class CoreDataManager {
                 print("[CoreData] container 로드 완료")
             }
         }
+        // background에서 일어나는 작업을 자동으로 main 컨텍스트에 병합해주는 설정
+        persistentContainer.viewContext.automaticallyMergesChangesFromParent = true
     }
 
     var context: NSManagedObjectContext {

--- a/Sodam/Sodam/Model/Repository/HangdamRepository + Extension.swift
+++ b/Sodam/Sodam/Model/Repository/HangdamRepository + Extension.swift
@@ -18,7 +18,6 @@ extension HangdamRepository {
 
     func fetchCurrentHangdmaAsync() async throws -> HangdamDTO {
         let hangdams: [HangdamEntity] = try await coreDataManager.fetchEntitiesAsync(
-            entityType: hangdamType,
             context: coredataContext
         )
 
@@ -27,7 +26,6 @@ extension HangdamRepository {
             return dtoMapper.toDTO(from: currentHangdam)
         } else {
             let newHangdam: HangdamEntity = try await coreDataManager.createEntityAsync(
-                type: hangdamType,
                 context: coredataContext
             )
             return dtoMapper.toDTO(from: newHangdam)
@@ -36,7 +34,6 @@ extension HangdamRepository {
 
     func fetchHangdamsAsync() async throws -> [HangdamDTO] {
         let hangdams: [HangdamEntity] = try await coreDataManager.fetchEntitiesAsync(
-            entityType: hangdamType,
             context: coredataContext
         ).dropLast()
 

--- a/Sodam/Sodam/Model/Repository/HangdamRepository + Extension.swift
+++ b/Sodam/Sodam/Model/Repository/HangdamRepository + Extension.swift
@@ -36,5 +36,7 @@ extension HangdamRepository {
     func nameHangdamAsync(id: String?, name: String) async throws {
         let hangdam: HangdamEntity = try await coreDataManager.fetchEntityByIdAsync(id: id, context: coredataContext)
         hangdam.name = name
+        
+        try coredataContext.save()
     }
 }

--- a/Sodam/Sodam/Model/Repository/HangdamRepository + Extension.swift
+++ b/Sodam/Sodam/Model/Repository/HangdamRepository + Extension.swift
@@ -9,24 +9,24 @@ import CoreData
 
 extension HangdamRepository {
     func fetchHangdamByIdAsync(id: String?) async throws -> HangdamDTO {
-        let hangdam: HangdamEntity = try await coreDataManager.fetchEntityByIdAsync(id: id)
+        let hangdam: HangdamEntity = try await coreDataManager.fetchEntityByIdAsync(id: id, context: coredataContext)
         return dtoMapper.toDTO(from: hangdam)
     }
 
     func fetchCurrentHangdmaAsync() async throws -> HangdamDTO {
-        let hangdams: [HangdamEntity] = try await coreDataManager.fetchEntitiesAsync(entityType: hangdamType)
+        let hangdams: [HangdamEntity] = try await coreDataManager.fetchEntitiesAsync(entityType: hangdamType, context: coredataContext)
 
         if let currentHangdam: HangdamEntity = hangdams.last,
            currentHangdam.endDate == nil {
             return dtoMapper.toDTO(from: currentHangdam)
         } else {
-            let newHangdam: HangdamEntity = try await coreDataManager.createEntityAsync(type: hangdamType)
+            let newHangdam: HangdamEntity = try await coreDataManager.createEntityAsync(type: hangdamType, context: coredataContext)
             return dtoMapper.toDTO(from: newHangdam)
         }
     }
 
     func fetchHangdamsAsync() async throws -> [HangdamDTO] {
-        let hangdams: [HangdamEntity] = try await coreDataManager.fetchEntitiesAsync(entityType: hangdamType).dropLast()
+        let hangdams: [HangdamEntity] = try await coreDataManager.fetchEntitiesAsync(entityType: hangdamType, context: coredataContext).dropLast()
 
         return hangdams.compactMap { hangdam in
             dtoMapper.toDTO(from: hangdam)
@@ -34,16 +34,7 @@ extension HangdamRepository {
     }
 
     func nameHangdamAsync(id: String?, name: String) async throws {
-        try await coreDataManager.performBackgroundTaskAsync { context in
-            guard let id: NSManagedObjectID = IDConverter.toNSManagedObjectID(from: id, in: context) else {
-                throw DataError.convertIDFailed
-            }
-
-            guard let hangdam: HangdamEntity = context.object(with: id) as? HangdamEntity else {
-                throw DataError.backgroundTaskFailed
-            }
-
-            hangdam.name = name
-        }
+        let hangdam: HangdamEntity = try await coreDataManager.fetchEntityByIdAsync(id: id, context: coredataContext)
+        hangdam.name = name
     }
 }

--- a/Sodam/Sodam/Model/Repository/HangdamRepository + Extension.swift
+++ b/Sodam/Sodam/Model/Repository/HangdamRepository + Extension.swift
@@ -9,24 +9,36 @@ import CoreData
 
 extension HangdamRepository {
     func fetchHangdamByIdAsync(id: String?) async throws -> HangdamDTO {
-        let hangdam: HangdamEntity = try await coreDataManager.fetchEntityByIdAsync(id: id, context: coredataContext)
+        let hangdam: HangdamEntity = try await coreDataManager.fetchEntityByIdAsync(
+            id: id,
+            context: coredataContext
+        )
         return dtoMapper.toDTO(from: hangdam)
     }
 
     func fetchCurrentHangdmaAsync() async throws -> HangdamDTO {
-        let hangdams: [HangdamEntity] = try await coreDataManager.fetchEntitiesAsync(entityType: hangdamType, context: coredataContext)
+        let hangdams: [HangdamEntity] = try await coreDataManager.fetchEntitiesAsync(
+            entityType: hangdamType,
+            context: coredataContext
+        )
 
         if let currentHangdam: HangdamEntity = hangdams.last,
            currentHangdam.endDate == nil {
             return dtoMapper.toDTO(from: currentHangdam)
         } else {
-            let newHangdam: HangdamEntity = try await coreDataManager.createEntityAsync(type: hangdamType, context: coredataContext)
+            let newHangdam: HangdamEntity = try await coreDataManager.createEntityAsync(
+                type: hangdamType,
+                context: coredataContext
+            )
             return dtoMapper.toDTO(from: newHangdam)
         }
     }
 
     func fetchHangdamsAsync() async throws -> [HangdamDTO] {
-        let hangdams: [HangdamEntity] = try await coreDataManager.fetchEntitiesAsync(entityType: hangdamType, context: coredataContext).dropLast()
+        let hangdams: [HangdamEntity] = try await coreDataManager.fetchEntitiesAsync(
+            entityType: hangdamType,
+            context: coredataContext
+        ).dropLast()
 
         return hangdams.compactMap { hangdam in
             dtoMapper.toDTO(from: hangdam)
@@ -34,9 +46,12 @@ extension HangdamRepository {
     }
 
     func nameHangdamAsync(id: String?, name: String) async throws {
-        let hangdam: HangdamEntity = try await coreDataManager.fetchEntityByIdAsync(id: id, context: coredataContext)
+        let hangdam: HangdamEntity = try await coreDataManager.fetchEntityByIdAsync(
+            id: id,
+            context: coredataContext
+        )
         hangdam.name = name
-        
+
         try coredataContext.save()
     }
 }

--- a/Sodam/Sodam/Model/Repository/HangdamRepository + Extension.swift
+++ b/Sodam/Sodam/Model/Repository/HangdamRepository + Extension.swift
@@ -1,0 +1,49 @@
+//
+//  HangdamRepository + Extension.swift
+//  Sodam
+//
+//  Created by 박진홍 on 2/19/25.
+//
+
+import CoreData
+
+extension HangdamRepository {
+    func fetchHangdamByIdAsync(id: String?) async throws -> HangdamDTO {
+        let hangdam: HangdamEntity = try await coreDataManager.fetchEntityByIdAsync(id: id)
+        return dtoMapper.toDTO(from: hangdam)
+    }
+
+    func fetchCurrentHangdmaAsync() async throws -> HangdamDTO {
+        let hangdams: [HangdamEntity] = try await coreDataManager.fetchEntitiesAsync(entityType: hangdamType)
+
+        if let currentHangdam: HangdamEntity = hangdams.last,
+           currentHangdam.endDate == nil {
+            return dtoMapper.toDTO(from: currentHangdam)
+        } else {
+            let newHangdam: HangdamEntity = try await coreDataManager.createEntityAsync(type: hangdamType)
+            return dtoMapper.toDTO(from: newHangdam)
+        }
+    }
+
+    func fetchHangdamsAsync() async throws -> [HangdamDTO] {
+        let hangdams: [HangdamEntity] = try await coreDataManager.fetchEntitiesAsync(entityType: hangdamType).dropLast()
+
+        return hangdams.compactMap { hangdam in
+            dtoMapper.toDTO(from: hangdam)
+        }
+    }
+
+    func nameHangdamAsync(id: String?, name: String) async throws {
+        try await coreDataManager.performBackgroundTaskAsync { context in
+            guard let id: NSManagedObjectID = IDConverter.toNSManagedObjectID(from: id, in: context) else {
+                throw DataError.convertIDFailed
+            }
+
+            guard let hangdam: HangdamEntity = context.object(with: id) as? HangdamEntity else {
+                throw DataError.backgroundTaskFailed
+            }
+
+            hangdam.name = name
+        }
+    }
+}

--- a/Sodam/Sodam/Model/Repository/HangdamRepository + Extension.swift
+++ b/Sodam/Sodam/Model/Repository/HangdamRepository + Extension.swift
@@ -9,6 +9,8 @@ import CoreData
 
 extension HangdamRepository {
     func fetchHangdamByIdAsync(id: String?) async throws -> HangdamDTO {
+        let coredataContext: NSManagedObjectContext = coreDataManager.persistentContainer.newBackgroundContext()
+        coredataContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
         let hangdam: HangdamEntity = try await coreDataManager.fetchEntityByIdAsync(
             id: id,
             context: coredataContext
@@ -17,6 +19,8 @@ extension HangdamRepository {
     }
 
     func fetchCurrentHangdmaAsync() async throws -> HangdamDTO {
+        let coredataContext: NSManagedObjectContext = coreDataManager.persistentContainer.newBackgroundContext()
+        coredataContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
         let hangdams: [HangdamEntity] = try await coreDataManager.fetchEntitiesAsync(
             context: coredataContext
         )
@@ -33,6 +37,8 @@ extension HangdamRepository {
     }
 
     func fetchHangdamsAsync() async throws -> [HangdamDTO] {
+        let coredataContext: NSManagedObjectContext = coreDataManager.persistentContainer.newBackgroundContext()
+        coredataContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
         let hangdams: [HangdamEntity] = try await coreDataManager.fetchEntitiesAsync(
             context: coredataContext
         ).dropLast()
@@ -43,6 +49,8 @@ extension HangdamRepository {
     }
 
     func nameHangdamAsync(id: String?, name: String) async throws {
+        let coredataContext: NSManagedObjectContext = coreDataManager.persistentContainer.newBackgroundContext()
+        coredataContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
         let hangdam: HangdamEntity = try await coreDataManager.fetchEntityByIdAsync(
             id: id,
             context: coredataContext

--- a/Sodam/Sodam/Model/Repository/HangdamRepository.swift
+++ b/Sodam/Sodam/Model/Repository/HangdamRepository.swift
@@ -12,7 +12,6 @@ import CoreData
 final class HangdamRepository {
     let coreDataManager: CoreDataManager
     let dtoMapper: HangdamMapper
-    let hangdamType: HangdamEntity.Type = HangdamEntity.self
     let coredataContext: NSManagedObjectContext
     init(
         coreDataManager: CoreDataManager = CoreDataManager.shared,

--- a/Sodam/Sodam/Model/Repository/HangdamRepository.swift
+++ b/Sodam/Sodam/Model/Repository/HangdamRepository.swift
@@ -10,8 +10,9 @@ import CoreData
 
 /// CoreDataManager와 ViewModel 사이에서 행담이 데이터 처리를 맡는 객체
 final class HangdamRepository {
-    private let coreDataManager: CoreDataManager
-    private let dtoMapper: HangdamMapper
+    let coreDataManager: CoreDataManager
+    let dtoMapper: HangdamMapper
+    let hangdamType: HangdamEntity.Type = HangdamEntity.self
 
     init(
         coreDataManager: CoreDataManager = CoreDataManager.shared,

--- a/Sodam/Sodam/Model/Repository/HangdamRepository.swift
+++ b/Sodam/Sodam/Model/Repository/HangdamRepository.swift
@@ -13,13 +13,16 @@ final class HangdamRepository {
     let coreDataManager: CoreDataManager
     let dtoMapper: HangdamMapper
     let hangdamType: HangdamEntity.Type = HangdamEntity.self
-
+    let coredataContext: NSManagedObjectContext
     init(
         coreDataManager: CoreDataManager = CoreDataManager.shared,
-        dtoMapper: HangdamMapper = .init()
+        dtoMapper: HangdamMapper = .init(),
+        coredataContext: NSManagedObjectContext? = nil
     ) {
         self.coreDataManager = coreDataManager
         self.dtoMapper = dtoMapper
+        self.coredataContext = coredataContext ?? coreDataManager.persistentContainer.newBackgroundContext()
+        self.coredataContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
     }
 
     /// 현재 키우는 행담이 불러오기

--- a/Sodam/Sodam/Model/Repository/HangdamRepository.swift
+++ b/Sodam/Sodam/Model/Repository/HangdamRepository.swift
@@ -12,16 +12,12 @@ import CoreData
 final class HangdamRepository {
     let coreDataManager: CoreDataManager
     let dtoMapper: HangdamMapper
-    let coredataContext: NSManagedObjectContext
     init(
         coreDataManager: CoreDataManager = CoreDataManager.shared,
-        dtoMapper: HangdamMapper = .init(),
-        coredataContext: NSManagedObjectContext? = nil
+        dtoMapper: HangdamMapper = .init()
     ) {
         self.coreDataManager = coreDataManager
         self.dtoMapper = dtoMapper
-        self.coredataContext = coredataContext ?? coreDataManager.persistentContainer.newBackgroundContext()
-        self.coredataContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
     }
 
     /// 현재 키우는 행담이 불러오기

--- a/Sodam/Sodam/Model/Repository/HappinessRepository + Extension.swift
+++ b/Sodam/Sodam/Model/Repository/HappinessRepository + Extension.swift
@@ -9,39 +9,59 @@ import CoreData
 
 extension HappinessRepository {
     func addHappinessAsync(happiness: HappinessDTO) async throws {
-        guard let id: NSManagedObjectID = IDConverter.toNSManagedObjectID(from: happiness.hangdamID, in: coredataContext) else {
+        guard let id: NSManagedObjectID = IDConverter.toNSManagedObjectID(
+            from: happiness.hangdamID,
+            in: coredataContext
+        ) else {
             throw DataError.convertIDFailed
         }
-        
+
         self.updateHangdamIfNeeded(hangdamID: id)
-        
-        try await self.dtoMapper.toEntity(from: happiness, context: coredataContext).asyncFold { [weak self] happinessEntity in
+
+        try await self.dtoMapper
+            .toEntity(from: happiness, context: coredataContext)
+            .asyncFold { [weak self] happinessEntity in
             guard let self = self else { throw DataError.selfIsNil }
-            let hangdamEntity: HangdamEntity = try await self.coreDataManager.fetchEntityByIdAsync(id: happiness.hangdamID, context: coredataContext)
-            
+                let hangdamEntity: HangdamEntity = try await self.coreDataManager.fetchEntityByIdAsync(
+                    id: happiness.hangdamID,
+                    context: coredataContext
+                )
+
             hangdamEntity.addToHappinesses(happinessEntity)
-            
+
         } onFailure: { error in
             print(error.localizedDescription)
             throw error
         }
     }
-    
-    func fetchHappinessAsync(of HangdamId: String?) async throws -> [HappinessDTO] {
-        let hangdamEntity: HangdamEntity = try await coreDataManager.fetchEntityByIdAsync(id: HangdamId, context: coredataContext)
+
+    func fetchHappinessAsync(of hangdamId: String?) async throws -> [HappinessDTO] {
+        let hangdamEntity: HangdamEntity = try await coreDataManager.fetchEntityByIdAsync(
+            id: hangdamId,
+            context: coredataContext
+        )
         let predicate: NSPredicate = NSPredicate(format: "hangdam == %@", hangdamEntity)
         let sortDescriptor: NSSortDescriptor = NSSortDescriptor(key: "date", ascending: false)
-        
-        let happiness: [HappinessEntity] = try await coreDataManager.fetchEntitiesAsync(entityType: happinessType, context: coredataContext, predicate: predicate, sortDescriptors: [sortDescriptor])
-        
+
+        let happiness: [HappinessEntity] = try await coreDataManager.fetchEntitiesAsync(
+            entityType: happinessType,
+            context: coredataContext,
+            predicate: predicate,
+            sortDescriptors: [sortDescriptor]
+        )
+
         return happiness.compactMap { happinessEntity in
             dtoMapper.toDTO(from: happinessEntity)
         }
     }
-    
+
     func deleteHappinessAsync(with id: String?, path: String?) async throws {
-        try await coreDataManager.deleteEntityByIdAsync(id: id, type: HappinessEntity.self, context: coredataContext)
-        
+        try await coreDataManager.deleteEntityByIdAsync(
+            id: id,
+            type: HappinessEntity.self,
+            context: coredataContext
+        )
+
         guard let path = path else { return }
         imageManager.deleteImage(path)
     }

--- a/Sodam/Sodam/Model/Repository/HappinessRepository + Extension.swift
+++ b/Sodam/Sodam/Model/Repository/HappinessRepository + Extension.swift
@@ -9,6 +9,8 @@ import CoreData
 
 extension HappinessRepository {
     func addHappinessAsync(happiness: HappinessDTO) async throws {
+        let coredataContext: NSManagedObjectContext = coreDataManager.persistentContainer.newBackgroundContext()
+        coredataContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
         guard let id: NSManagedObjectID = IDConverter.toNSManagedObjectID(
             from: happiness.hangdamID,
             in: coredataContext
@@ -36,6 +38,8 @@ extension HappinessRepository {
     }
 
     func fetchHappinessAsync(of hangdamId: String?) async throws -> [HappinessDTO] {
+        let coredataContext: NSManagedObjectContext = coreDataManager.persistentContainer.newBackgroundContext()
+        coredataContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
         let hangdamEntity: HangdamEntity = try await coreDataManager.fetchEntityByIdAsync(
             id: hangdamId,
             context: coredataContext
@@ -55,6 +59,8 @@ extension HappinessRepository {
     }
 
     func deleteHappinessAsync(with id: String?, path: String?) async throws {
+        let coredataContext: NSManagedObjectContext = coreDataManager.persistentContainer.newBackgroundContext()
+        coredataContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
         try await coreDataManager.deleteEntityByIdAsync(
             id: id,
             type: HappinessEntity.self,
@@ -101,6 +107,8 @@ extension HappinessRepository {
     }
 
     func checkHappinessCountAsync(with hangdamId: String?) async throws -> Int? {
+        let coredataContext: NSManagedObjectContext = coreDataManager.persistentContainer.newBackgroundContext()
+        coredataContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
         let hangdam: HangdamEntity = try await coreDataManager.fetchEntityByIdAsync(
             id: hangdamId,
             context: coredataContext

--- a/Sodam/Sodam/Model/Repository/HappinessRepository + Extension.swift
+++ b/Sodam/Sodam/Model/Repository/HappinessRepository + Extension.swift
@@ -8,26 +8,41 @@
 import CoreData
 
 extension HappinessRepository {
-    func addNewHappiness(happiness: HappinessDTO) async throws {
-        try await coreDataManager.performBackgroundTaskAsync { [weak self] context in
-            guard let self = self else { throw DataError.selfIsNil }
-            guard let id: NSManagedObjectID = IDConverter.toNSManagedObjectID(from: happiness.hangdamID, in: context) else {
-                throw DataError.convertIDFailed
-            }
-            
-            self.updateHangdamIfNeeded(hangdamID: id)
-            
-            try self.dtoMapper.toEntity(from: happiness, context: context).fold { happinessEntity in
-                guard let hangdamEntity = try context.existingObject(with: id) as? HangdamEntity else {
-                    throw DataError.searchEntityFailed
-                }
-                
-                hangdamEntity.addToHappinesses(happinessEntity)
-                
-            } onFailure: { error in
-                print(error.localizedDescription)
-                throw error
-            }
+    func addHappinessAsync(happiness: HappinessDTO) async throws {
+        guard let id: NSManagedObjectID = IDConverter.toNSManagedObjectID(from: happiness.hangdamID, in: coredataContext) else {
+            throw DataError.convertIDFailed
         }
+        
+        self.updateHangdamIfNeeded(hangdamID: id)
+        
+        try await self.dtoMapper.toEntity(from: happiness, context: coredataContext).asyncFold { [weak self] happinessEntity in
+            guard let self = self else { throw DataError.selfIsNil }
+            let hangdamEntity: HangdamEntity = try await self.coreDataManager.fetchEntityByIdAsync(id: happiness.hangdamID, context: coredataContext)
+            
+            hangdamEntity.addToHappinesses(happinessEntity)
+            
+        } onFailure: { error in
+            print(error.localizedDescription)
+            throw error
+        }
+    }
+    
+    func fetchHappinessAsync(of HangdamId: String?) async throws -> [HappinessDTO] {
+        let hangdamEntity: HangdamEntity = try await coreDataManager.fetchEntityByIdAsync(id: HangdamId, context: coredataContext)
+        let predicate: NSPredicate = NSPredicate(format: "hangdam == %@", hangdamEntity)
+        let sortDescriptor: NSSortDescriptor = NSSortDescriptor(key: "date", ascending: false)
+        
+        let happiness: [HappinessEntity] = try await coreDataManager.fetchEntitiesAsync(entityType: happinessType, context: coredataContext, predicate: predicate, sortDescriptors: [sortDescriptor])
+        
+        return happiness.compactMap { happinessEntity in
+            dtoMapper.toDTO(from: happinessEntity)
+        }
+    }
+    
+    func deleteHappinessAsync(with id: String?, path: String?) async throws {
+        try await coreDataManager.deleteEntityByIdAsync(id: id, type: HappinessEntity.self, context: coredataContext)
+        
+        guard let path = path else { return }
+        imageManager.deleteImage(path)
     }
 }

--- a/Sodam/Sodam/Model/Repository/HappinessRepository + Extension.swift
+++ b/Sodam/Sodam/Model/Repository/HappinessRepository + Extension.swift
@@ -1,0 +1,33 @@
+//
+//  HappinessRepository + Extension.swift
+//  Sodam
+//
+//  Created by 박진홍 on 2/19/25.
+//
+
+import CoreData
+
+extension HappinessRepository {
+    func addNewHappiness(happiness: HappinessDTO) async throws {
+        try await coreDataManager.performBackgroundTaskAsync { [weak self] context in
+            guard let self = self else { throw DataError.selfIsNil }
+            guard let id: NSManagedObjectID = IDConverter.toNSManagedObjectID(from: happiness.hangdamID, in: context) else {
+                throw DataError.convertIDFailed
+            }
+            
+            self.updateHangdamIfNeeded(hangdamID: id)
+            
+            try self.dtoMapper.toEntity(from: happiness, context: context).fold { happinessEntity in
+                guard let hangdamEntity = try context.existingObject(with: id) as? HangdamEntity else {
+                    throw DataError.searchEntityFailed
+                }
+                
+                hangdamEntity.addToHappinesses(happinessEntity)
+                
+            } onFailure: { error in
+                print(error.localizedDescription)
+                throw error
+            }
+        }
+    }
+}

--- a/Sodam/Sodam/Model/Repository/HappinessRepository + Extension.swift
+++ b/Sodam/Sodam/Model/Repository/HappinessRepository + Extension.swift
@@ -44,7 +44,6 @@ extension HappinessRepository {
         let sortDescriptor: NSSortDescriptor = NSSortDescriptor(key: "date", ascending: false)
 
         let happiness: [HappinessEntity] = try await coreDataManager.fetchEntitiesAsync(
-            entityType: happinessType,
             context: coredataContext,
             predicate: predicate,
             sortDescriptors: [sortDescriptor]

--- a/Sodam/Sodam/Model/Repository/HappinessRepository.swift
+++ b/Sodam/Sodam/Model/Repository/HappinessRepository.swift
@@ -14,7 +14,6 @@ final class HappinessRepository {
     let coreDataManager: CoreDataManager
     let imageManager: ImageManager
     let dtoMapper: HappinessMapper
-    let happinessType: HappinessEntity.Type = HappinessEntity.self
     let coredataContext: NSManagedObjectContext
 
     init(

--- a/Sodam/Sodam/Model/Repository/HappinessRepository.swift
+++ b/Sodam/Sodam/Model/Repository/HappinessRepository.swift
@@ -15,15 +15,19 @@ final class HappinessRepository {
     let imageManager: ImageManager
     let dtoMapper: HappinessMapper
     let happinessType: HappinessEntity.Type = HappinessEntity.self
+    let coredataContext: NSManagedObjectContext
 
     init(
         coreDataManager: CoreDataManager = CoreDataManager.shared,
         imageManager: ImageManager = ImageManager(),
-        dtoMapper: HappinessMapper = .init()
+        dtoMapper: HappinessMapper = .init(),
+        context: NSManagedObjectContext? = nil
     ) {
         self.coreDataManager = coreDataManager
         self.imageManager = imageManager
         self.dtoMapper = dtoMapper
+        self.coredataContext = context ?? coreDataManager.persistentContainer.newBackgroundContext()
+        self.coredataContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
     }
 
     /// 행복한 기억 생성

--- a/Sodam/Sodam/Model/Repository/HappinessRepository.swift
+++ b/Sodam/Sodam/Model/Repository/HappinessRepository.swift
@@ -11,9 +11,10 @@ import CoreData
 
 /// CoreDataManager와 ViewModel 사이에서 행복한 기억 데이터 처리를 맡는 객체
 final class HappinessRepository {
-    private let coreDataManager: CoreDataManager
-    private let imageManager: ImageManager
-    private let dtoMapper: HappinessMapper
+    let coreDataManager: CoreDataManager
+    let imageManager: ImageManager
+    let dtoMapper: HappinessMapper
+    let happinessType: HappinessEntity.Type = HappinessEntity.self
 
     init(
         coreDataManager: CoreDataManager = CoreDataManager.shared,
@@ -44,7 +45,7 @@ final class HappinessRepository {
     /// 행담이가 가진 기존 행복 개수 체크하여 경우에 따라 이벤트 발생 또는 데이터
     ///
     /// createHappiness에서 guard문으로 이미 NSManagedObjectID type으로 변환한 값을 전달 받음
-    private func updateHangdamIfNeeded(hangdamID: NSManagedObjectID) {
+    func updateHangdamIfNeeded(hangdamID: NSManagedObjectID) {
         guard let count = coreDataManager.checkHappinessCount(with: hangdamID) else { return }
 
         switch count {

--- a/Sodam/Sodam/Model/Repository/HappinessRepository.swift
+++ b/Sodam/Sodam/Model/Repository/HappinessRepository.swift
@@ -98,7 +98,7 @@ final class HappinessRepository {
 }
 
 extension HappinessRepository {
-    private func postNotification(level: Int) {
+    func postNotification(level: Int) {
         NotificationCenter.default.post(name: Notification.levelUP, object: nil, userInfo: ["level": level])
     }
 }

--- a/Sodam/Sodam/Model/Repository/HappinessRepository.swift
+++ b/Sodam/Sodam/Model/Repository/HappinessRepository.swift
@@ -14,19 +14,15 @@ final class HappinessRepository {
     let coreDataManager: CoreDataManager
     let imageManager: ImageManager
     let dtoMapper: HappinessMapper
-    let coredataContext: NSManagedObjectContext
 
     init(
         coreDataManager: CoreDataManager = CoreDataManager.shared,
         imageManager: ImageManager = ImageManager(),
-        dtoMapper: HappinessMapper = .init(),
-        context: NSManagedObjectContext? = nil
+        dtoMapper: HappinessMapper = .init()
     ) {
         self.coreDataManager = coreDataManager
         self.imageManager = imageManager
         self.dtoMapper = dtoMapper
-        self.coredataContext = context ?? coreDataManager.persistentContainer.newBackgroundContext()
-        self.coredataContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
     }
 
     /// 행복한 기억 생성


### PR DESCRIPTION
## 1. 요약 
기존 메서드들을 모두 대체할 수 있도록 비동기 처리 메서드를 구현했습니다.
context를 새로 받아 사용하는 김에 코어데이터 매니저의 메서드도 고도화했습니다.

<details>
<summary>설명</summary>
#  Core Data 비동기 처리 리팩토링

**주요 변경 사항**
- **CoreDataManager**
  - 전달받은 컨텍스트를 사용해 안전하게 비동기 작업을 수행하도록 메서드들을 수정했습니다.
    (`createEntityAsync`, `fetchEntityByIdAsync`, `fetchEntitiesAsync`, `deleteEntityByIdAsync`)
  - 기존의 구체적인 메서드보다 추상화된 메서드로 작성하고 세부 구현은 Repository에서 처리합니다.
  - 컨텍스트 주입 없이 새로운 백그라운드 작업은 `performBackgroundTaskAsync`로 처리할 수 있습니다.

- **HangdamRepository**
  - 기존 메서드들을 참고하여 비동기 처리 및 새롭게 바뀐 코어데이터 메서드에 맞춰 작성했습니다.
    (`fetchHangdamByIdAsync`, `fetchCurrentHangdmaAsync`, `fetchHangdamsAsync`, `nameHangdamAsync`)

- **HappinessRepository**
   - 기존 메서드들을 참고하여 비동기 처리 및 새롭게 바뀐 코어데이터 메서드에 맞춰 작성했습니다.
    (`addHappinessAsync`, `fetchHappinessAsync`, `deleteHappinessAsync`)

**핵심 요약**
- 모든 Core Data 작업을 async/await와 withCheckedThrowingContinuation으로 감싸 비동기로 처리
- continuation은 async로 사용하도록 감싸는 것일 뿐이고 내부적인 비동기처리는 백그라운드 컨텍스트에서 처리됨
- 공유 컨텍스트를 주입받아 perform으로 처리하며 mergePolicy 설정으로 데이터가 꼬일 확률 줄임
- 컨텍스트는 repository별로 backgroundContext 생성해서 사용
- 에러는 DataError로 통일하여 처리
</details>

## 2. 스크린샷 
## 3. 공유사항

뷰모델 적용은 별개의 작업으로 리팩터링을 할 예정입니다.
뷰모델 적용 전에 이미지 매니저에 대한 비동기 처리를 먼저 할 듯 합니다.
