### PR TITLE
[Fix] 작성뷰 커서 버그 수정

### DIFF
--- a/Sodam/Sodam/View/Main/WriteView/WriteView.swift
+++ b/Sodam/Sodam/View/Main/WriteView/WriteView.swift
@@ -134,6 +134,11 @@ class WriteView: UIView {
         super.init(coder: coder)
         setupUI()
     }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        updateTextViewAttributes() // 뷰가 레이아웃을 설정한 후 스타일 적용
+    }
 }
 
 // MARK: - UI 레이아웃 메서드
@@ -270,7 +275,7 @@ extension WriteView {
 // MARK: - 텍스트뷰 메서드
 extension WriteView {
     // placeholder 숨김처리 메서드
-    private func updatePlaceholderVisibility() {
+    func updatePlaceholderVisibility() {
         placeholderLabel.isHidden = !textView.text.isEmpty
     }
 
@@ -307,8 +312,6 @@ extension WriteView {
     // 텍스트뷰 내용 변경 메서드
     func setTextViewText(_ text: String) {
         textView.text = text
-        updatePlaceholderVisibility() // 텍스트 변경 시 Placeholder 업데이트
-        updateTextViewAttributes() // 텍스트 변경 시 스타일 적용
     }
     
     // 텍스트뷰 입력 활성화 해제 메서드 (키보드 내리기 위함) - 작성 완료 버튼 액션 함수에서 호출

--- a/Sodam/Sodam/View/Main/WriteView/WriteViewController.swift
+++ b/Sodam/Sodam/View/Main/WriteView/WriteViewController.swift
@@ -58,6 +58,9 @@ final class WriteViewController: UIViewController {
         writeViewModel.loadTemporaryPost()
         let currentCount = writeView.getTextViewText().count
         writeView.setCharacterLimitLabel(currentCount)
+        if currentCount > 0 {
+            writeView.updatePlaceholderVisibility()
+        }
     }
 
     override func viewDidLoad() {
@@ -291,7 +294,9 @@ extension WriteViewController: ImagePickerServiceDelegate {
 extension WriteViewController: WriteViewModelDelegate {
     /// 뷰모델에게 작성 내용 전달받는 메서드
     func didUpdatePost(_ text: String, _ isEmpty: Bool) {
-        writeView.setTextViewText(text) // 텍스트뷰 업데이트
+        if writeView.getTextViewText() != text {
+            writeView.setTextViewText(text)
+        }
         writeView.collectionViewReload() // 컬렉션 뷰 리로드
         writeView.updateCollectionViewConstraint(isEmpty) // 이미지 유무에 따라 컬렉션뷰 숨김처리
     }
@@ -301,19 +306,23 @@ extension WriteViewController: WriteViewModelDelegate {
 extension WriteViewController: UITextViewDelegate {
     func textViewDidChange(_ textView: UITextView) {
         let maxCharacterCount = 500 // 글자 수 제한
-        let limitedText = String(textView.text.prefix(maxCharacterCount))
-
+        let currentText: String = textView.text // 현재 작성 글
+        let currentCount = currentText.count // 현재 글자 수
+        let limitedText = String(currentText.prefix(maxCharacterCount)) // 글자 수 제한이 적용된 글
+        
         // 글자 수 제한 초과하면 Alert 띄우기
-        if textView.text.count > maxCharacterCount {
+        if currentCount > maxCharacterCount {
             alertManager.showAlert(alertMessage: .textLimit)
             writeView.setTextViewText(limitedText) // 초과된 부분 삭제
         }
+        
+        // placeholder 숨김 처리
+        writeView.updatePlaceholderVisibility()
         
         // 텍스트가 변경될 때마다 뷰모델에 전달
         writeViewModel.updateText(limitedText)
         
         // 현재 글자 수 전달
-        let currentCount = textView.text.count
         writeView.setCharacterLimitLabel(currentCount)
     }
 }


### PR DESCRIPTION
## 1. 요약 
- 작성뷰 커서가 항상 글 맨 뒤로 가던 문제 수정했습니다.
## 2. 스크린샷 
### 기존 문제 화면 
![커서문제](https://github.com/user-attachments/assets/200a3f78-b012-48f6-9104-728f5cd17b51)

### 해결한 화면
![커서문제해결](https://github.com/user-attachments/assets/48546d43-668b-4451-8015-ee4ed851306c)

## 3. 공유사항
- 글이 바뀔 때마다 텍스트뷰 내용이 업데이트 되고 리로드되며 생긴 문제였습니다. 
- 매번 업데이트 되지 않도록 조건문을 추가하여 문제를 해결했습니다. 
- 작성뷰가 로드 되면서 임시 저장된 내용이 있을 때만 텍스트뷰 업데이트 메서드가 호출되기 때문에, 작성뷰를 한 번 띄워놓은 뒤로는 글을 마음대로 수정해도 텍스트뷰의 업데이트 및 리로드가 이루어 지지 않아 커서가 맘대로 맨 뒤로 가는 일이 없어졌습니다.
- 텍스트뷰 업데이트 메서드가 변경됨에 따라 텍스트뷰 업데이트 메서드에서 호출되던 글 간격 Attribute와 placeholder처리 메서들의 호출 위치가 조금 변경되었습니다.