### PR TITLE
[Feat] 생체 인증을 통한 앱 잠금 기능

### DIFF
--- a/Sodam/Sodam/Configuration/Info.plist
+++ b/Sodam/Sodam/Configuration/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSFaceIDUsageDescription</key>
+	<string>앱 잠금 기능을 사용하기 위하여 Face ID 인증 허용이 필요합니다.</string>
 	<key>UIUserInterfaceStyle</key>
 	<string>Light</string>
 	<key>UIAppFonts</key>

--- a/Sodam/Sodam/Delegate/SceneDelegate.swift
+++ b/Sodam/Sodam/Delegate/SceneDelegate.swift
@@ -8,59 +8,72 @@
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-
+    
     var window: UIWindow?
-
+    
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         let window = UIWindow(windowScene: windowScene)
-
-        let isFirstLaunch = !UserDefaultsManager.shared.getHasLaunchedBefor()
+        window.backgroundColor = .white
+        self.window = window
         
-        // 메인 ViewController 설정
+        let biometricAuthManger: BiometricAuthManager = BiometricAuthManager()
+        let isFirstLaunch = !UserDefaultsManager.shared.getHasLaunchedBefor()
+        let useBiometrics = UserDefaultsManager.shared.getUseBiometric()
+        
+        let launchViewController = UIViewController()
+        window.rootViewController = launchViewController
+        window.makeKeyAndVisible()
+        
+        let targetViewController: UIViewController
+        
+        // 생체 인증을 사용하지 않는 경우 바로 메인 화면 or 온보딩 화면으로 이동
+        // 첫 실행 시 온보딩 화면 아닌 경우 메인 화면
         if isFirstLaunch {
-            // 첫 실행 시 온보딩 화면으로 시작
+            biometricAuthManger.setupBiometryType() // touch id인지 face id인지 확인 후 저장
+            
             let onboardingViewController = OnBoardingViewController()
             onboardingViewController.modalPresentationStyle = .fullScreen
             onboardingViewController.onComplete = { [weak self] in
-                print("완료 콜백 호출됨")
-                self?.navigateToRootViewController()
+                self?.navigateToRootViewController(rootViewController: CustomTabBarController())
             }
-            window.rootViewController = onboardingViewController
+            targetViewController = onboardingViewController
         } else {
-            // 첫 실행 아닐 땐 기존대로 커스텀탭바 컨트롤러로 시작
-            window.rootViewController = CustomTabBarController()
+            if useBiometrics {
+                // 사용자가 생체 인증을 활성화한 경우 LockViewController 띄우기
+                let lockViewController = LockViewController(biometricAuthManager: biometricAuthManger)
+                lockViewController.onAuthenticationSuccess = { [weak self] in
+                    self?.navigateToRootViewController(rootViewController: CustomTabBarController())
+                }
+                targetViewController = lockViewController
+            } else {
+                targetViewController = CustomTabBarController()
+            }
         }
-
-        window.backgroundColor = .white
-
+        
         // 페이드인/페이드아웃 오버레이 설정
         let overlayView = UIView(frame: UIScreen.main.bounds)
         let imageView = UIImageView(image: UIImage(named: "LaunchImage"))
         imageView.contentMode = .scaleAspectFill
         imageView.frame = overlayView.bounds
         overlayView.addSubview(imageView)
-
+        
         overlayView.alpha = 1.0 // 처음에 보이는 상태로 시작 함
-
-        self.window = window
-        window.makeKeyAndVisible()
-
-        // 오버레이 추가
         window.addSubview(overlayView)
-
-        // 페이드아웃 후 메인 화면 전환 + 페이드인
-        UIView.animate(withDuration: 0.8, delay: 1.5, options: .curveEaseOut, animations: {
-            overlayView.alpha = 0.0 // 페이드아웃
-        }, completion: { _ in
-
-            // 메인 뷰 페이드인 애니메이션
-            UIView.animate(withDuration: 0.7, animations: {
-                window.rootViewController?.view.alpha = 1.0 // 메인 뷰 서서히 나타남
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            UIView.animate(withDuration: 0.8, delay: 0, options: .curveEaseOut, animations: {
+                overlayView.alpha = 0.0 // 페이드아웃
+            }, completion: { _ in
+                // 메인 뷰 페이드인 애니메이션
+                UIView.transition(with: window, duration: 0.7, options: .transitionCrossDissolve, animations: {
+                    window.rootViewController = targetViewController
+                    window.rootViewController?.view.alpha = 1.0 // 메인 뷰 서서히 나타남
+                }, completion: nil)
+                
+                overlayView.removeFromSuperview() // 오버레이 제거
             })
-
-            overlayView.removeFromSuperview() // 오버레이 제거
-        })
+        }
     }
     
     func sceneDidBecomeActive(_ scene: UIScene) {
@@ -68,20 +81,20 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
     
     /**
-    // 앱이 백그라운드로 전환될 때 일기 작성 여부 확인
-    func sceneDidEnterBackground(_ scene: UIScene) {
-        LocalNotificationManager.shared.checkDiaryAndCancelNotification()
-    }
-    */
+     // 앱이 백그라운드로 전환될 때 일기 작성 여부 확인
+     func sceneDidEnterBackground(_ scene: UIScene) {
+     LocalNotificationManager.shared.checkDiaryAndCancelNotification()
+     }
+     */
     
     // MARK: - 온보딩 화면 종료 후 메인 화면 이동
-    private func navigateToRootViewController() {
-        let mainViewController = CustomTabBarController()
-        let window = UIApplication.shared.windows.first
-        UIView.transition(with: window!, duration: 0.5, options: .transitionCrossDissolve, animations: {
-            window?.rootViewController = mainViewController
+    private func navigateToRootViewController(rootViewController: UIViewController) {
+        guard let window = self.window else { return }
+
+        UIView.transition(with: window, duration: 0.7, options: .transitionCrossDissolve, animations: {
+            window.rootViewController = rootViewController
         }, completion: { _ in
-            window?.makeKeyAndVisible()
+            window.makeKeyAndVisible()
         })
     }
 }

--- a/Sodam/Sodam/Model/Manager/Alert/AlertManager.swift
+++ b/Sodam/Sodam/Model/Manager/Alert/AlertManager.swift
@@ -180,3 +180,26 @@ final class AlertManager {
         viewController?.present(alertController, animated: true)
     }
 }
+
+// MARK: - 생체 인증 Alert
+extension AlertManager {
+    /// 생체 인증 권한 알림
+    func showBiometricPermissionAlert() {
+       let setBiometricPermission = UIAlertAction(title: "설정으로 이동", style: .default) { _ in
+            if let url = URL(string: UIApplication.openSettingsURLString) {
+                UIApplication.shared.open(url)
+            }
+        }
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+        showAlert(alertMessage: .biometryNotEnrolled, actions: [setBiometricPermission, cancelAction])
+    }
+    
+    /// 인증 실패 시 재시도 알림
+    func showRetryBiometricAlert(retryHandler: @escaping () -> Void) {
+        let retryAction = UIAlertAction(title: "다시 시도", style: .default) { _ in
+            retryHandler()
+        }
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+        showAlert(alertMessage: .authenticationFailed, actions: [retryAction, cancelAction])
+    }
+}

--- a/Sodam/Sodam/Model/Manager/Alert/AlertTypes.swift
+++ b/Sodam/Sodam/Model/Manager/Alert/AlertTypes.swift
@@ -17,7 +17,17 @@ enum AlertMessage {
     case cameraPermission
     case imagePermission
     case textLimit
-
+    case biometryAvailable
+    case biometryNotAvailable
+    case biometryNotEnrolled
+    case authenticationFailed
+    case biometryLockout
+    case userCancel
+    case userFallback
+    case systemCancel
+    case passcodeNotSet
+    case unknownBiometryError
+    
     var title: String {
         switch self {
         case .emptyText:
@@ -34,6 +44,26 @@ enum AlertMessage {
             return "현재 사진 라이브러리 접근에 대한 권한이 없습니다."
         case .textLimit:
             return "글자 수 제한 초과"
+        case .biometryAvailable:
+            return "생체 인증 성공"
+        case .biometryNotAvailable:
+            return "생체 인증을 사용할 수 없음"
+        case .biometryNotEnrolled:
+            return "생체 인증이 설정되지 않음"
+        case .authenticationFailed:
+            return "생체 인증 실패"
+        case .biometryLockout:
+            return "생체 인증이 잠김"
+        case .userCancel:
+            return "인증이 취소되었습니다"
+        case .userFallback:
+            return "암호 입력 선택됨"
+        case .systemCancel:
+            return "시스템에 의해 인증이 취소됨"
+        case .passcodeNotSet:
+            return "기기에 암호가 설정되지 않음"
+        case .unknownBiometryError:
+            return "알 수 없는 오류"
         }
     }
 
@@ -51,6 +81,26 @@ enum AlertMessage {
             return "설정 > Sodam 탭에서 접근 권한을 활성화 해주세요."
         case .textLimit:
             return "최대 입력 글자는 500자 입니다."
+        case .biometryAvailable:
+            return "앱 잠금이 활성화 되었습니다."
+        case .biometryNotAvailable:
+            return "이 기기에서는 생체 인증을 사용할 수 없습니다."
+        case .biometryNotEnrolled:
+            return "생체 인증을 사용하려면 설정에서 권한을 허용해주세요."
+        case .authenticationFailed:
+            return "인증에 실패했습니다. 다시 시도해주세요."
+        case .biometryLockout:
+            return "생체 인증을 여러 번 실패하여 잠금 상태입니다. 기기 암호를 입력해주세요."
+        case .userCancel:
+            return "인증을 취소했습니다."
+        case .userFallback:
+            return "암호 입력을 선택했습니다. 잠금을 해제하려면 암호를 입력해주세요."
+        case .systemCancel:
+            return "다른 앱 사용 또는 시스템 이벤트로 인해 인증이 취소되었습니다."
+        case .passcodeNotSet:
+            return "생체 인증을 사용하려면 기기 암호를 설정해야 합니다."
+        case .unknownBiometryError:
+            return "알 수 없는 오류로 생체 인증에 실패했습니다."
         }
     }
 }

--- a/Sodam/Sodam/Model/Manager/Alert/AlertTypes.swift
+++ b/Sodam/Sodam/Model/Manager/Alert/AlertTypes.swift
@@ -23,9 +23,7 @@ enum AlertMessage {
     case authenticationFailed
     case biometryLockout
     case userCancel
-    case userFallback
     case systemCancel
-    case passcodeNotSet
     case unknownBiometryError
     
     var title: String {
@@ -56,12 +54,8 @@ enum AlertMessage {
             return "생체 인증이 잠김"
         case .userCancel:
             return "인증이 취소되었습니다"
-        case .userFallback:
-            return "암호 입력 선택됨"
         case .systemCancel:
             return "시스템에 의해 인증이 취소됨"
-        case .passcodeNotSet:
-            return "기기에 암호가 설정되지 않음"
         case .unknownBiometryError:
             return "알 수 없는 오류"
         }
@@ -93,12 +87,8 @@ enum AlertMessage {
             return "생체 인증을 여러 번 실패하여 잠금 상태입니다. 기기 암호를 입력해주세요."
         case .userCancel:
             return "인증을 취소했습니다."
-        case .userFallback:
-            return "암호 입력을 선택했습니다. 잠금을 해제하려면 암호를 입력해주세요."
         case .systemCancel:
             return "다른 앱 사용 또는 시스템 이벤트로 인해 인증이 취소되었습니다."
-        case .passcodeNotSet:
-            return "생체 인증을 사용하려면 기기 암호를 설정해야 합니다."
         case .unknownBiometryError:
             return "알 수 없는 오류로 생체 인증에 실패했습니다."
         }

--- a/Sodam/Sodam/Model/Manager/Alert/AlertTypes.swift
+++ b/Sodam/Sodam/Model/Manager/Alert/AlertTypes.swift
@@ -53,7 +53,7 @@ enum AlertMessage {
         case .biometryLockout:
             return "생체 인증이 잠김"
         case .userCancel:
-            return "인증이 취소되었습니다"
+            return "인증이 취소됨"
         case .systemCancel:
             return "시스템에 의해 인증이 취소됨"
         case .unknownBiometryError:
@@ -84,11 +84,11 @@ enum AlertMessage {
         case .authenticationFailed:
             return "인증에 실패했습니다. 다시 시도해주세요."
         case .biometryLockout:
-            return "생체 인증을 여러 번 실패하여 잠금 상태입니다. 기기 암호를 입력해주세요."
+            return "생체 인증을 여러 번 실패하여 생체 인증이 잠겼습니다."
         case .userCancel:
             return "인증을 취소했습니다."
         case .systemCancel:
-            return "다른 앱 사용 또는 시스템 이벤트로 인해 인증이 취소되었습니다."
+            return "다른 앱 사용 또는 시스템에 의해 인증이 취소되었습니다."
         case .unknownBiometryError:
             return "알 수 없는 오류로 생체 인증에 실패했습니다."
         }

--- a/Sodam/Sodam/Model/Manager/BiometricAuthManager.swift
+++ b/Sodam/Sodam/Model/Manager/BiometricAuthManager.swift
@@ -1,0 +1,78 @@
+//
+//  BiometricAuthManager.swift
+//  Sodam
+//
+//  Created by 박민석 on 3/6/25.
+//
+
+import Foundation
+import LocalAuthentication
+
+final class BiometricAuthManager {
+
+    private var biometryTypeString: String = "Face ID 또는 Touch ID" // 기본값
+    
+    /// 현재 기기가 Face ID인지, Touch ID인지 확인 후 저장
+    func setupBiometryType() {
+        print("[BiometricAuthManager] 생체 인증 타입 \(biometryTypeString)으로 저장됨")
+        let context = LAContext()
+        if context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil) {
+            switch context.biometryType {
+            case .faceID:
+                biometryTypeString = "Face ID"
+            case .touchID:
+                biometryTypeString = "Touch ID"
+            default:
+                biometryTypeString = "Face ID 또는 Touch ID"
+            }
+            UserDefaultsManager.shared.saveBiometricsType(biometryTypeString)
+        }
+    }
+    
+    /// 생체 인증 사용 가능 여부 확인
+    func isBiometricAvailable() -> Bool {
+        let context = LAContext()
+        return context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil)
+    }
+    
+    /// 인증 실행 (생체 인증 + 암호 인증)
+    func authenticateUser(reason: String, completion: @escaping (Bool, LAError.Code?) -> Void) {
+        let context = LAContext()
+        
+        context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: reason) { success, error in
+            DispatchQueue.main.async {
+                if success {
+                    print("[BiometricAuthManager] 인증 성공")
+                    completion(true, nil)
+                } else {
+                    if let laError = error as? LAError {
+                        switch laError.code {
+                        case .biometryNotAvailable:
+                            print("[BiometricAuthManager] 기기가 생체 인증을 지원하지 않음")
+                        case .biometryNotEnrolled:
+                            print("[BiometricAuthManager] 사용자가 생체 인증을 등록하지 않음")
+                        case .biometryLockout:
+                            print("[BiometricAuthManager] 생체 인증이 여러 번 실패하여 잠김")
+                        case .authenticationFailed:
+                            print("[BiometricAuthManager] 생체 인증 시도 실패")
+                        case .userCancel:
+                            print("[BiometricAuthManager] 사용자가 인증 취소")
+                        case .userFallback:
+                            print("[BiometricAuthManager] 사용자가 암호 입력 선택")
+                        case .systemCancel:
+                            print("[BiometricAuthManager] 다른 앱이 활성화되어 인증이 취소됨")
+                        case .passcodeNotSet:
+                            print("[BiometricAuthManager] 기기에 암호(PIN)가 설정되지 않음")
+                        default:
+                            print("[BiometricAuthManager] 기타 오류 발생: \(laError.localizedDescription)")
+                        }
+                        completion(false, laError.code)
+                    } else {
+                        print("[BiometricAuthManager] 알 수 없는 오류 발생")
+                        completion(false, nil)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Sodam/Sodam/Model/Manager/BiometricAuthManager.swift
+++ b/Sodam/Sodam/Model/Manager/BiometricAuthManager.swift
@@ -36,10 +36,10 @@ final class BiometricAuthManager {
         return context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil)
     }
     
-    /// 인증 실행 (생체 인증 + 암호 인증)
+    /// 인증 실행 (생체 인증만)
     func authenticateUser(reason: String, completion: @escaping (Bool, LAError.Code?) -> Void) {
         let context = LAContext()
-        context.localizedFallbackTitle = "" // 암호 인증 비활성화
+        context.localizedFallbackTitle = "" // 암호 입력 버튼 비활성화
         
         context.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: reason) { success, error in
             DispatchQueue.main.async {

--- a/Sodam/Sodam/Model/Manager/BiometricAuthManager.swift
+++ b/Sodam/Sodam/Model/Manager/BiometricAuthManager.swift
@@ -11,7 +11,6 @@ import LocalAuthentication
 final class BiometricAuthManager {
 
     private var biometryTypeString: String = "Face ID 또는 Touch ID" // 기본값
-//    private let context = LAContext()
     
     /// 현재 기기가 Face ID인지, Touch ID인지 확인 후 저장
     func setupBiometryType() {

--- a/Sodam/Sodam/Model/Manager/UserDefaultsManager.swift
+++ b/Sodam/Sodam/Model/Manager/UserDefaultsManager.swift
@@ -37,6 +37,10 @@ final class UserDefaultsManager {
         
         // MARK: - Name
         static let hangdamName = "hangdamName" // 이름
+        
+        // MARK: - 앱 잠금
+        static let useBiometricsKey = "useBiometrics"
+        static let biometricsType = "biometricsType"
     }
 }
 
@@ -159,5 +163,28 @@ extension UserDefaultsManager {
     // 이름 가져오기
     func getHangdamName() -> String {
         return userDefaults.string(forKey: Keys.hangdamName) ?? "행담이"
+    }
+}
+
+// MARK: - 앱 잠금
+extension UserDefaultsManager {
+    /// 앱 잠금 사용 여부 저장
+    func setUseBiometrics(_ isEnabled: Bool) {
+        UserDefaults.standard.set(isEnabled, forKey: Keys.useBiometricsKey)
+    }
+    
+    /// 앱 잠금 사용 여부 반환
+    func getUseBiometrics() -> Bool {
+        return UserDefaults.standard.bool(forKey: Keys.useBiometricsKey)
+    }
+    
+    /// 앱 잠금 방식 저장
+    func saveBiometricsType(_ biomerticsType: String) {
+        UserDefaults.standard.set(biomerticsType, forKey: Keys.biometricsType)
+    }
+    
+    // 앱 잠금 방식 반환
+    func getBiometricsType() -> String? {
+        return userDefaults.string(forKey: Keys.biometricsType)
     }
 }

--- a/Sodam/Sodam/Model/Manager/UserDefaultsManager.swift
+++ b/Sodam/Sodam/Model/Manager/UserDefaultsManager.swift
@@ -39,8 +39,8 @@ final class UserDefaultsManager {
         static let hangdamName = "hangdamName" // 이름
         
         // MARK: - 앱 잠금
-        static let useBiometricsKey = "useBiometrics"
-        static let biometricsType = "biometricsType"
+        static let useBiometricKey = "useBiometric"
+        static let biometricType = "biometricType"
     }
 }
 
@@ -169,22 +169,22 @@ extension UserDefaultsManager {
 // MARK: - 앱 잠금
 extension UserDefaultsManager {
     /// 앱 잠금 사용 여부 저장
-    func setUseBiometrics(_ isEnabled: Bool) {
-        UserDefaults.standard.set(isEnabled, forKey: Keys.useBiometricsKey)
+    func setUseBiometric(_ isEnabled: Bool) {
+        UserDefaults.standard.set(isEnabled, forKey: Keys.useBiometricKey)
     }
     
     /// 앱 잠금 사용 여부 반환
-    func getUseBiometrics() -> Bool {
-        return UserDefaults.standard.bool(forKey: Keys.useBiometricsKey)
+    func getUseBiometric() -> Bool {
+        return UserDefaults.standard.bool(forKey: Keys.useBiometricKey)
     }
     
     /// 앱 잠금 방식 저장
-    func saveBiometricsType(_ biomerticsType: String) {
-        UserDefaults.standard.set(biomerticsType, forKey: Keys.biometricsType)
+    func saveBiometricType(_ biomerticsType: String) {
+        UserDefaults.standard.set(biomerticsType, forKey: Keys.biometricType)
     }
     
     // 앱 잠금 방식 반환
-    func getBiometricsType() -> String? {
-        return userDefaults.string(forKey: Keys.biometricsType)
+    func getBiometricType() -> String? {
+        return userDefaults.string(forKey: Keys.biometricType)
     }
 }

--- a/Sodam/Sodam/View/LockView/LockViewController.swift
+++ b/Sodam/Sodam/View/LockView/LockViewController.swift
@@ -1,0 +1,83 @@
+//
+//  LockViewController.swift
+//  Sodam
+//
+//  Created by 박민석 on 3/6/25.
+//
+
+import UIKit
+
+final class LockViewController: UIViewController {
+    
+    private let biometricAuthManager: BiometricAuthManager
+    private lazy var alertManager = AlertManager(viewController: self)
+    
+    var onAuthenticationSuccess: (() -> Void)? // 인증 완료 후 실행할 클로저
+    private let biometryTypeString: String = UserDefaultsManager.shared.getBiometricType() ?? "Face ID 또는 Touch ID"
+    
+    init(biometricAuthManager: BiometricAuthManager) {
+        self.biometricAuthManager = biometricAuthManager
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+        print("LockViewController view did load")
+        // 권한 확인 후 요청
+        let granted = biometricAuthManager.isBiometricAvailable()
+        if granted {
+            authenticateUser()
+        } else {
+            alertManager.showBiometricPermissionAlert()
+        }
+    }
+
+    private func authenticateUser() {
+        print("[LockViewController] \(biometryTypeString) 인증 실행")
+        let reason = "앱을 잠금을 해제하려면 \(biometryTypeString) 인증이 필요합니다."
+        biometricAuthManager.authenticateUser(reason: reason) { [weak self] success, errorCode in
+            guard let self = self else { return }
+            if success {
+                self.onAuthenticationSuccess?()
+            } else {
+                guard let errorCode = errorCode else {
+                    print("[LockViewController] 알 수 없는 에러로 앱 잠금 설정 실패")
+                    self.alertManager.showAlert(alertMessage: .unknownBiometryError)
+                    return
+                }
+                
+                // 실패 이유에 따른 분기 처리
+                switch errorCode {
+                case .biometryNotEnrolled, .biometryNotAvailable:
+                    print("[LockViewController] 잠금 해제 실패 - 생체 인증이 등록되어 있지 않거나 권한이 거부됨")
+                    self.alertManager.showBiometricPermissionAlert()
+                case .biometryLockout:
+                    print("[LockViewController] 잠금 해제 실패 - 여러번 실패하여 생체 인증 기능이 잠김")
+                    showAuthenticationFailedAlert()
+                case .userCancel:
+                    print("[LockViewController] 잠금 해제 실패 - 사용자가 인증을 취소함")
+                    showAuthenticationFailedAlert()
+                case .systemCancel:
+                    print("[LockViewController] 잠금 해제 실패 - 시스템에 의해 인증이 취소됨")
+                    showAuthenticationFailedAlert()
+                default:
+                    print("[LockViewController] 잠금 해제 실패 - 기타 오류 발생")
+                    self.alertManager.showAlert(alertMessage: .unknownBiometryError)
+                }
+            }
+        }
+    }
+    
+    private func showAuthenticationFailedAlert() {
+        print("[LockViewController] \(biometryTypeString)인증 및 암호 인증 실패 Alert 호출")
+        alertManager.showRetryBiometricAlert { [weak self] in
+            guard let self = self else { return }
+            self.authenticateUser()
+        }
+    }
+}

--- a/Sodam/Sodam/View/LockView/LockViewController.swift
+++ b/Sodam/Sodam/View/LockView/LockViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+/// 앱 잠금 활성화 후 앱 실행시 생체 인증을 수행할 뷰컨트롤러
 final class LockViewController: UIViewController {
     
     private let biometricAuthManager: BiometricAuthManager
@@ -37,6 +38,7 @@ final class LockViewController: UIViewController {
         }
     }
 
+    /// 인증 진행 메서드
     private func authenticateUser() {
         print("[LockViewController] \(biometryTypeString) 인증 실행")
         let reason = "앱을 잠금을 해제하려면 \(biometryTypeString) 인증이 필요합니다."
@@ -73,11 +75,12 @@ final class LockViewController: UIViewController {
         }
     }
     
+    /// 인증 실패시 재시도 Alert을 띄우기 위한 메서드
     private func showAuthenticationFailedAlert() {
         print("[LockViewController] \(biometryTypeString)인증 및 암호 인증 실패 Alert 호출")
         alertManager.showRetryBiometricAlert { [weak self] in
             guard let self = self else { return }
-            self.authenticateUser()
+            self.authenticateUser() // 인증 재시도
         }
     }
 }

--- a/Sodam/Sodam/View/Setting/Helper/Setting.swift
+++ b/Sodam/Sodam/View/Setting/Helper/Setting.swift
@@ -13,6 +13,7 @@ enum Setting {
         case appSetting = "앱 설정"
         case develop = "환경 설정"
         case fontSetting = "폰트 설정"
+        case lockSetting = "앱 잠금 설정"
     }
 
     // 설정 Cell
@@ -20,6 +21,7 @@ enum Setting {
         case notification = "알림 설정"  // 알림 스위치
         case setTime = "시간"
         case fontSetting = "폰트 설정"
+        case biometricAuth = "앱 잠금"
         case appReview = "앱 리뷰 남기기" // 앱 리뷰 남기러 가기
         case appVersion = "앱 버전"     // 앱 버전
         case feedback = "버그제보 / 문의" // 사용자 피드백

--- a/Sodam/Sodam/View/Setting/SettingViewModel.swift
+++ b/Sodam/Sodam/View/Setting/SettingViewModel.swift
@@ -12,7 +12,7 @@ final class SettingViewModel {
     private let localNotificationManager = LocalNotificationManager.shared
 
     var isToggleOn: Bool   // 앱 설정 토글 상태
-    let sectionType: [Setting.SetSection] = [.appSetting, .fontSetting, .develop]   // 섹션 타입 설정
+    let sectionType: [Setting.SetSection] = [.appSetting, .fontSetting, .lockSetting, .develop]   // 섹션 타입 설정
     
     // 앱 버전을 가져오는 computed property
     var version: String? {
@@ -60,6 +60,11 @@ extension SettingViewModel {
         userDefaultsManager.saveAppToggleState(isOn)
     }
     
+    // 앱 잠금 토글 상태 저장
+    func saveBiometrics(_ isOn: Bool) {
+        userDefaultsManager.setUseBiometrics(isOn)
+    }
+    
     // MARK: - Get Methods
     
     // 저장된 알림 시간 가져오기
@@ -75,6 +80,11 @@ extension SettingViewModel {
     // 사용자가 설정한 예약된 알림 설정
     func setUserNotification() {
         localNotificationManager.setUserNotification()
+    }
+    
+    // 앱 잠금 토글 상태 가져오기
+    func getBiometrics() -> Bool {
+        userDefaultsManager.getUseBiometrics()
     }
 }
 

--- a/Sodam/Sodam/View/Setting/SettingViewModel.swift
+++ b/Sodam/Sodam/View/Setting/SettingViewModel.swift
@@ -61,7 +61,7 @@ extension SettingViewModel {
     }
     
     // 앱 잠금 토글 상태 저장
-    func saveBiometrics(_ isOn: Bool) {
+    func saveBiometricsState(_ isOn: Bool) {
         userDefaultsManager.setUseBiometrics(isOn)
     }
     
@@ -83,7 +83,7 @@ extension SettingViewModel {
     }
     
     // 앱 잠금 토글 상태 가져오기
-    func getBiometrics() -> Bool {
+    func getBiometricsState() -> Bool {
         userDefaultsManager.getUseBiometrics()
     }
 }

--- a/Sodam/Sodam/View/Setting/SettingViewModel.swift
+++ b/Sodam/Sodam/View/Setting/SettingViewModel.swift
@@ -61,8 +61,8 @@ extension SettingViewModel {
     }
     
     // 앱 잠금 토글 상태 저장
-    func saveBiometricsState(_ isOn: Bool) {
-        userDefaultsManager.setUseBiometrics(isOn)
+    func saveBiometricState(_ isOn: Bool) {
+        userDefaultsManager.setUseBiometric(isOn)
     }
     
     // MARK: - Get Methods
@@ -83,8 +83,8 @@ extension SettingViewModel {
     }
     
     // 앱 잠금 토글 상태 가져오기
-    func getBiometricsState() -> Bool {
-        userDefaultsManager.getUseBiometrics()
+    func getBiometricState() -> Bool {
+        userDefaultsManager.getUseBiometric()
     }
 }
 

--- a/Sodam/Sodam/View/Setting/SettingsViewController.swift
+++ b/Sodam/Sodam/View/Setting/SettingsViewController.swift
@@ -310,7 +310,6 @@ extension SettingsViewController: UITableViewDataSource, UITableViewDelegate {
                 self.alertManager.showAlert(alertMessage: .biometryAvailable) // 앱 잠금 활성화 alert 띄우기
             } else {
                 // 생체 인증 거부 or 인증 실패
-                
                 // 알 수 없는 이유로 실패시 alert
                 guard let errorCode = errorCode else {
                     print("[SettingViewController] 알 수 없는 에러로 앱 잠금 설정 실패")

--- a/Sodam/Sodam/View/Setting/SettingsViewController.swift
+++ b/Sodam/Sodam/View/Setting/SettingsViewController.swift
@@ -295,13 +295,14 @@ extension SettingsViewController: UITableViewDataSource, UITableViewDelegate {
     @objc func didToggleBiometricAuthSwitch(_ sender: UISwitch) {
         // 스위치가 꺼졌을 경우
         guard sender.isOn == true else {
-            print("[SettingViewController] 앱 잠금 토글 스위치 꺼짐]")
+            print("[SettingViewController] 앱 잠금 토글 스위치 꺼짐")
             settingViewModel.saveBiometricState(sender.isOn)
             return
         }
         
         print("[SettingViewController] 앱 잠금 토글 스위치 켜짐")
-        biometricAuthManager.authenticateUser(reason: "잠금을 해제하려면 인증이 필요합니다.") { success, errorCode in
+        biometricAuthManager.authenticateUser(reason: "잠금을 해제하려면 인증이 필요합니다.") { [weak self] success, errorCode in
+            guard let self = self else { return }
             if success {
                 // 생체 인증 허용 & 인증 성공
                 print("[SettingViewController] 생체 인증 권한 허용 및 인증 성공")

--- a/Sodam/Sodam/View/Setting/SettingsViewController.swift
+++ b/Sodam/Sodam/View/Setting/SettingsViewController.swift
@@ -135,6 +135,8 @@ extension SettingsViewController: UITableViewDataSource, UITableViewDelegate {
             return settingViewModel.isToggleOn ? 2 : 1
         case .fontSetting:
             return 1
+        case .lockSetting:
+            return 1
         case .develop:
             return 3
         }
@@ -196,6 +198,7 @@ extension SettingsViewController: UITableViewDataSource, UITableViewDelegate {
                            switchAction: nil,
                            timeAction: nil,
                            version: "")
+            
         case .lockSetting:
             cell.arrowImage.isHidden = true
             cell.timePicker.isHidden = true
@@ -206,7 +209,7 @@ extension SettingsViewController: UITableViewDataSource, UITableViewDelegate {
                            switchAction: #selector(didToggleBiometricAuthSwitch(_:)),
                            timeAction: nil,
                            version: "")
-            cell.switchButton.isOn = settingViewModel.getBiometrics() // 저장된 토글 상태 반영
+            cell.switchButton.isOn = settingViewModel.getBiometricsState() // 저장된 토글 상태 반영
 
         case .develop:
             cell.timePicker.isHidden = true
@@ -287,7 +290,7 @@ extension SettingsViewController: UITableViewDataSource, UITableViewDelegate {
     
     // 앱잠금 스위치 상태가 변경 되었을 때 호출되는 액션
     @objc func didToggleBiometricAuthSwitch(_ sender: UISwitch) {
-        settingViewModel.saveBiometrics(sender.isOn)
+        settingViewModel.saveBiometricsState(sender.isOn)
     }
     
     private func updateNotificationState(isEnabled: Bool) {

--- a/Sodam/Sodam/View/Setting/SettingsViewController.swift
+++ b/Sodam/Sodam/View/Setting/SettingsViewController.swift
@@ -196,6 +196,17 @@ extension SettingsViewController: UITableViewDataSource, UITableViewDelegate {
                            switchAction: nil,
                            timeAction: nil,
                            version: "")
+        case .lockSetting:
+            cell.arrowImage.isHidden = true
+            cell.timePicker.isHidden = true
+            cell.switchButton.isHidden = false
+            cell.versionLabel.isHidden = true
+            
+            cell.configure(title: Setting.SetCell.biometricAuth.rawValue,
+                           switchAction: #selector(didToggleBiometricAuthSwitch(_:)),
+                           timeAction: nil,
+                           version: "")
+            cell.switchButton.isOn = settingViewModel.getBiometrics() // 저장된 토글 상태 반영
 
         case .develop:
             cell.timePicker.isHidden = true
@@ -272,6 +283,11 @@ extension SettingsViewController: UITableViewDataSource, UITableViewDelegate {
                 self.updateToggleState()
             }
         }
+    }
+    
+    // 앱잠금 스위치 상태가 변경 되었을 때 호출되는 액션
+    @objc func didToggleBiometricAuthSwitch(_ sender: UISwitch) {
+        settingViewModel.saveBiometrics(sender.isOn)
     }
     
     private func updateNotificationState(isEnabled: Bool) {

--- a/Sodam/Sodam/View/TabBar/CustomTabBarController.swift
+++ b/Sodam/Sodam/View/TabBar/CustomTabBarController.swift
@@ -29,6 +29,8 @@ final class CustomTabBarController: UITabBarController {
         let happinessRepository: HappinessRepository = HappinessRepository()
         let mainViewModel: MainViewModel = MainViewModel(repository: hangdamRepository)
         let storageViewModel: HangdamStorageViewModel = HangdamStorageViewModel(hangdamRepository: hangdamRepository)
+        
+        let biometricAuthManager: BiometricAuthManager = BiometricAuthManager()
 
         let detailViewOperator: DetailViewOperator = DetailViewOperator(happinessRepository: happinessRepository)
         let listViewReloader: ListViewReloading = CurrentListViewReloader(
@@ -73,7 +75,7 @@ final class CustomTabBarController: UITabBarController {
 
         // 설정 탭
         let settingViewModel = SettingViewModel()
-        let settingsViewController = SettingsViewController(settingViewModel: settingViewModel)
+        let settingsViewController = SettingsViewController(settingViewModel: settingViewModel, biometricAuthManager: biometricAuthManager)
         let settingsNavController = UINavigationController(rootViewController: settingsViewController)
         settingsNavController.tabBarItem = UITabBarItem(
             title: "설정",


### PR DESCRIPTION
## 1. 요약 
- 생체인증을 통한 앱 잠금을 추가하였습니다.

## 2. 스크린샷 
### 앱 잠금 토글 추가
<img src="https://github.com/user-attachments/assets/a678a080-bdca-4123-8eb7-c8d745b2e0ff" alt="이미지1" width="200">

- 설정 화면에 앱 잠금 토글을 추가했습니다.

### 앱 잠금 활성화
| <img src="https://github.com/user-attachments/assets/0aed6cd3-9fc7-49a2-8cf0-757712e3283b" alt="이미지1" width="200"> | <img src="https://github.com/user-attachments/assets/d5350bc1-8044-454e-b61b-4a3daaf3b369" alt="이미지2" width="200"> |<img src="https://github.com/user-attachments/assets/f1467e33-5061-4f67-a0ee-3a4d4d071c68" alt="이미지3" width="200"> |
|-------------------------------------------------------|-------------------------------------------------------|-------------------------------------------------------|
|앱 잠금 스위치 처음 켤 때 권한 요청|생체 인증 실패시 실패 alert|생체 인증 성공시 활성화 alert|

### 앱 잠금 활성화 후 앱 실행시 동작
<img src="https://github.com/user-attachments/assets/77639505-e8f2-4cd0-a131-046f52dcfafd" alt="이미지1" width="200"> 

- 생체 인증 실패시 재시도 alert이 나오도록 하였고, 취소하면 아무 동작도 하지 않습니다.

## 3. 공유사항
### 1. 생체 인증을 위해 `LocalAuthentication`을 import하고, `BiometricAuthManager`로 객체화
- LocalAuthentication의 evaluatePolicy라는 메서드를 통해 로컬 인증 정책(Face ID 또는 Touch ID 등)을 평가하여 생체 인증이나 암호 인증을 진행 할 수 있습니다.
 ```swift
context.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: reason) { success, error in
...
}
```
- BiometricAuthManager로 객체화 한 이유는 SettingViewController와 LockViewController(앱 잠금 활성화 후 앱 실행시 맨 처음 동작할 뷰컨트롤러) 2군데에서 사용되어야 하고, ViewController로부터 생체 인증을 위한 코드를 분리하여 객체 지향 코드를 작성하고 싶었기 때문입니다.

### 2. 권한 요청에 대한 부분
- 권한 요청의 경우 Face ID 기기에서만 진행됩니다. Touch ID의 경우 기기에서 Touch ID가 활성화 되어 있다면 별도의 권한 요청 없이 생체 인증 진행이 가능합니다.
- 권한 요청의 경우, 위에서 이야기했던 evaluatePolicy를 통해 진행되는데, 처음 동작 할 경우 iOS가 알아서 info.plist에 추가한 권한요청 메세지를 띄워 권한 요청을 진행하고, 권한 요청이 진행된 적 있는 경우 같은 메서드로 알아서 인증 진행까지 수행합니다.
- 따라서 권한을 요청하는 것, 권한이 거부되거나 허가 되었을 때의 분기처리 등을 컨트롤 할 수 없었고, 하나의 메서드로 한 번에 알아서 권한 요청과 생체 인증이 진행되는 바람에 고민이 길었습니다.
- 결과적으로 메서드를 쓰는 건 그대로이고, LAError 라는  로컬 인증 정책의 에러를 통해 분기 처리를 시도했습니다.
```swift
if let laError = error as? LAError {
 switch laError.code {
  case .biometryNotAvailable:
  case 
  ...
  }
}
```
- 에러와 alert을 통해 간접적으로나마 권한 허용이나 생체 인증 동작의 분기 처리를 시도했고, 저 혼자 테스트 했을 땐 문제 없어 보였는데 팀원분들이 좀 더 다양하게 테스트 해주시면 감사하겠습니다..!!🙇

### 3. 암호 인증
![암호입력](https://github.com/user-attachments/assets/e891949a-3e8d-47cd-9de6-15dafd792633)
- 생체 인증이 2번 실패하고 나면, 위와 같은 [취소|암호 입력] 이 쓰여 있는 Alert이 자동으로 나오는데, 이 부분에 대해서도 고민이 많았습니다.
- 우선 암호 인증이 굳이 필요한가도 고민이었고, 암호 인증을 쓰지 않더라도 '암호 입력' Alert이 자동으로 나오기 때문에 어려움이 있었습니다. 또한, 암호 인증을 쓰고자 해도 별도의 처리를 하지 않으면 '암호 입력'을 눌러도 아무 동작도 없이 그냥 종료 됐었습니다.
- 암호 입력도 같이 사용하도록 하려고 별도 처리를 하면, '암호 입력'을 눌렀을 때 다시 또 생체인증부터 진행하게 되었습니다. 암호 인증과 생체 인증이 별도로 진행되지 않고, '암호 입력'을 눌러도 다시 생체 인증 2번을 진행 후 암호 입력 Alert이 나온뒤 암호 입력으로 넘어가는 것입니다..
- 위 예시 코드를 보면 아시겠지만 마치 CoreData때처럼 context를 써서 로컬 인증을 진행하게 되는 것인데, 이 context가 문제인듯 하여 새로 생성되게도 해보고, 사용 되던 context를 이어서 사용하게도 해보았는데 계속 같은 동작을 했습니다. 암호 인증만 따로 진행되지 않는 이유를 찾지 못한 것입니다.
- 시중에 있는 몇 개의 앱(토스, 트래블월렛, 꼬박일기) 앱을 확인해보니 토스와 트래블월렛은 Face ID 인증만 진행하고, 실패시 암호 입력 없이 취소만 가능하도록 하였고, 꼬박일기는 위에서 말한 '암호 입력' Alert이 나오지만 암호 입력을 눌러도 별도 동작 없이 그냥 종료 되었습니다.
- 결국 생체 인증 실패시 alert에서 암호 입력이 나오지 않도록 처리하였고, 스크린샷에서 볼 수 있는 [취소] 버튼만 있는 alert이 그 결과입니다. 위에서 말씀드린 토스나 트래블월렛과 같은 방식이라고 생각됩니다.
- 다만 공식문서에서 생체 인증이 실패할 경우 대체 인증을 진행하라고 하는 걸 보기도 해서, 리젝 당할 수도 있다는 걸 염두에 두고 있어야 합니다..🥲

### 4. 'Face ID' 혹은 'Touch ID'라고 띄우기
- 일단 Face ID 기기인지, Touch ID 기기인지 구분하는 방법은 간단하기 때문에, 구분한 뒤에 UserDefaults에 저장되도록 해두었습니다.
- 다만 이를 위해 BiometricAuthManager가 UserDefaultsManager를 의존하는데 이 부분이 조금 신경쓰이는 상태입니다.
- 그리고 마찬가지로, Label이나 Alert에도 'Face ID' 혹은 'Touch ID'를 띄우기 위해서는 필요한 곳에서 모두 UserDefaultsManager를 의존해야 하는데,  UserDefaultsManager가 싱글톤이라 상관 없나 싶기도 하고, 저희가 열심히 의존성 고민해서 분리 해보려고 애쓰는 와중에 UserDefaultsManager는 그냥 막 가져다 쓰는 게 맞는가 싶기도 해서 이 부분도 팀원 분들의 이야기가 듣고 싶었습니다.
- 일단은 그래서 'Face ID'나 'Touch ID'라고 안 나오고 그냥 '생체 인증'이나 '앱 잠금' 이라고 나오는 상태입니다.

### 참고
<img width="772" alt="스크린샷 2025-03-06 오후 1 13 18" src="https://github.com/user-attachments/assets/7853dcde-9af3-4a4e-afc4-8268c54ad0d0" />

참고로, LAError 에러 코드는 위와 같이 정리할 수 있는데, 표현이 조금 미묘한 느낌이 있습니다.

자세한 건 [LAError 공식문서](https://developer.apple.com/documentation/localauthentication/laerror-swift.struct)를 보시면 아실 수도 있는데, 설명이 워낙 간결해서 저는 써봐야 알겠더라구요..

`.biometryNotAvailable`은  공식 문서에도 `Biometry is not available on the device.` 이렇게만 쓰여있고, GPT 설명으로는 생체 인증이 불가능한 기기에서 생체 인증을 진행하려 할 경우 나는 것처럼 쓰여있습니다. 틀린 건 아닌데, Face ID 권한을 거부했을 때도 이 에러가 동작해서 `.biometryNotEnrolled`와 `.authenticationFailed`랑 구분하기 어려워 당황스러운 경우가 있었습니다.

로컬 인증 정책에 대한 것은 [LAPolicy 공식문서](https://developer.apple.com/documentation/localauthentication/lapolicy) 확인하면 편합니다..!